### PR TITLE
fix: persistent path issue during delete

### DIFF
--- a/ios/Plugin/CapacitorUpdater.swift
+++ b/ios/Plugin/CapacitorUpdater.swift
@@ -167,7 +167,7 @@ extension Bundle {
     
     @objc public func delete(version: String, versionName: String) -> Bool {
         let destHot = documentsUrl.appendingPathComponent(basePathHot).appendingPathComponent(version)
-        let destPersist = documentsUrl.appendingPathComponent(basePathPersist).appendingPathComponent(version)
+        let destPersist = libraryUrl.appendingPathComponent(basePathPersist).appendingPathComponent(version)
         do {
             try FileManager.default.removeItem(atPath: destHot.path)
         } catch {


### PR DESCRIPTION
This fixes the deletion of a version on iOS. Currently the versions don't get deleted in the persistent folder and the folder may grow and grow with each new version.