### PR TITLE
fix(android): handle CAP_SERVER_PATH empty string as default equivale…

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
@@ -500,7 +500,11 @@ public class CapacitorUpdater {
     }
 
     public String getCurrentBundlePath() {
-        return this.prefs.getString(WebView.CAP_SERVER_PATH, "public");
+        String path = this.prefs.getString(WebView.CAP_SERVER_PATH, "public");
+        if("".equals(path.trim())) {
+            return "public";
+        }
+        return path;
     }
 
     public Boolean isUsingBuiltin() {


### PR DESCRIPTION
…nt to 'public'