### PR TITLE
fix: use equals to compare checksum

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -688,7 +688,7 @@ public class CapacitorUpdaterPlugin extends Plugin implements Application.Activi
                                                             final BundleInfo next =
                                                                 CapacitorUpdaterPlugin.this.implementation.download(url, latestVersionName);
                                                             final String checksum = (String) res.get("checksum");
-                                                            if (!checksum.equals("") && next.getChecksum() != checksum) {
+                                                            if (!checksum.equals("") && !next.getChecksum().equals(checksum)) {
                                                                 Log.e(
                                                                     CapacitorUpdater.TAG,
                                                                     "Error checksum " + next.getChecksum() + " " + checksum


### PR DESCRIPTION
Seems like a typo. Using != to compare two instance of strings will always return true, which causes updates on android failed. By the way, thanks for providing such an easy to use solution for capacitor hot code push.