### PR TITLE
fix: issue #153 - crash when session key is null on Android

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
@@ -265,7 +265,7 @@ public class CapacitorUpdater {
           String id = bundle.getString(DownloadService.ID);
           String dest = bundle.getString(DownloadService.FILEDEST);
           String version = bundle.getString(DownloadService.VERSION);
-          String sessionKey = bundle.getString(DownloadService.SESSIONKEY);
+          String sessionKey = bundle.getString(DownloadService.SESSIONKEY, "");
           String checksum = bundle.getString(DownloadService.CHECKSUM);
           Log.i(
             CapacitorUpdater.TAG,


### PR DESCRIPTION
Fixes issue #153 