### PR TITLE
Fix int overflow in download percent Android

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
@@ -198,7 +198,7 @@ public class CapacitorUpdater {
           );
         }
 
-        final int newPercent = (int) ((lengthRead * 100) / lengthTotal);
+        final int newPercent = (int) ((bytesRead / (float)totalLength) * 100);
         if (lengthTotal > 1 && newPercent != percent) {
           percent = newPercent;
           this.notifyDownload(id, this.calcTotalPercent(percent, 75, 90));

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
@@ -198,7 +198,7 @@ public class CapacitorUpdater {
           );
         }
 
-        final int newPercent = (int) ((bytesRead / (float)totalLength) * 100);
+        final int newPercent = (int) ((lengthRead / (float)lengthTotal) * 100);
         if (lengthTotal > 1 && newPercent != percent) {
           percent = newPercent;
           this.notifyDownload(id, this.calcTotalPercent(percent, 75, 90));
@@ -424,7 +424,7 @@ public class CapacitorUpdater {
     this.notifyDownload(id, 10);
     while ((length = dis.read(buffer)) > 0) {
       fos.write(buffer, 0, length);
-      final int newPercent = (int) ((bytesRead * 100) / totalLength);
+      final int newPercent = (int) ((bytesRead / (float)totalLength) * 100);
       if (totalLength > 1 && newPercent != percent) {
         percent = newPercent;
         this.notifyDownload(id, this.calcTotalPercent(percent, 10, 70));


### PR DESCRIPTION
When the update zip is above 21474836 bytes (~20MB), the current way of computing the downloaded percent overflows and returns a negative number.
This fix changes this line:
`final int newPercent = (int) ((bytesRead * 100) / totalLength);`
To:
`final int newPercent = (int) ((bytesRead / (float)totalLength) * 100);`