### PR TITLE
Attempt to fix EXC_BAD_ACCESS during reset call

### DIFF
--- a/ios/Plugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Plugin/CapacitorUpdaterPlugin.swift
@@ -270,22 +270,22 @@ public class CapacitorUpdaterPlugin: CAPPlugin {
     @objc func _reset(toLastSuccessful: Bool) -> Bool {
         guard let bridge = self.bridge else { return false }
 
-        if let vc = bridge.viewController as? CAPBridgeViewController {
+        if (bridge.viewController as? CAPBridgeViewController) != nil {
             let fallback: BundleInfo = self.implementation.getFallbackBundle()
-            
+
             // If developer wants to reset to the last successful bundle, and that bundle is not
             // the built-in bundle, set it as the bundle to use and reload.
             if toLastSuccessful && !fallback.isBuiltin() {
                 print("\(self.implementation.TAG) Resetting to: \(fallback.toString())")
                 return self.implementation.set(bundle: fallback) && self._reload()
             }
-            
+
             // Otherwise, reset back to the built-in bundle and reload.
             self.implementation.reset()
-            self._reload()
-
-            return true
+            
+            return self._reload()
         }
+
         return false
     }
 

--- a/ios/Plugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Plugin/CapacitorUpdaterPlugin.swift
@@ -267,7 +267,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin {
         self.implementation.customId = customId
     }
 
-    objc func _reset(toLastSuccessful: Bool) -> Bool {
+    @objc func _reset(toLastSuccessful: Bool) -> Bool {
         guard let bridge = self.bridge else { return false }
 
         if let vc = bridge.viewController as? CAPBridgeViewController {

--- a/ios/Plugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Plugin/CapacitorUpdaterPlugin.swift
@@ -280,9 +280,10 @@ public class CapacitorUpdaterPlugin: CAPPlugin {
                 return self.implementation.set(bundle: fallback) && self._reload()
             }
 
+            print("\(self.implementation.TAG) Resetting to builtin version")
+            
             // Otherwise, reset back to the built-in bundle and reload.
             self.implementation.reset()
-            
             return self._reload()
         }
 


### PR DESCRIPTION
App was crashing due to an EXC_BAD_ACCESS exception that was only reproducible for me consistently on iPhone 8 and during a reset action. I suspect there is some race condition at play.

![Screen Shot 2023-02-08 at 8 54 22 PM](https://user-images.githubusercontent.com/7741481/217721442-d0a2f555-ec09-490e-93b5-e832a9975d29.png)


Not sure who else was running into an issue like this, but the context around the issue is that I wanted to rollback changes to the builtin bundle when I detected a need to. And this process I wanted to be performed during the application boot.

The repro steps that I followed were as follows:
- **iPhone 8** Emulator or Physical iPhone 8 running 15.6.1
- **iOS 15.5**
- CapacitorUpdater in manual mode, pretty much all features disabled via the config.
 
```
1. Fresh install of app (delete the app)
2. Install the app
3. Run it and download an update using `CapacitorUpdater.download()`.
4. Apply the update by calling `CapacitorUpdater.set()`
5. You should now be looking at the updated JS bundle, now:
6. Kill the app by swiping it or whatever (double press the home button on this iphone)
7. Open the app, you should still see the updated JS bundle.
8. Reinstall the same version of the app, just hit play in xcode.
9. App should be reinstalled, still showing the updated JS bundle.
10. LEAVE THE PHONE RUNNING THE APP. (prolly doesnt matter, but just what i have been doing)

Ok so from here you may need to add some logic to get this behavior

11. Now, build a NEW version of the app, and change the version to something that you have never used before lets say. so if I was on 2.5.0, maybe just choose 2.9.20.
         12. This new version needs to call `CapacitorUpdater.reset()` in the very beginning.
         13.  Basically what this step is for is we detect if the version of the app is different, and if so, rollback to the builtin bundle.
14. Install this version, you should be prompted by XCode to replace the app since its currently running if you followed the steps EXACTLY.
15. During this boot of the app, is where I get this exception.
```


The solution I found that seemed to fix this issue was to just use the core methods that already existed in this Plugin, instead of using the `DispatchQueue.main.async` call. Since conceptually, a reset is nothing more than:
- Set builtin as the current bundle
- Reload stuff
