### PR TITLE
Set correct bundle status SUCCESS on download completion

### DIFF
--- a/ios/Plugin/CapacitorUpdater.swift
+++ b/ios/Plugin/CapacitorUpdater.swift
@@ -487,14 +487,12 @@ extension CustomError: LocalizedError {
         semaphore.wait()
         if mainError != nil {
             // If we hit an error, update the bundle info as errored
-            let info: BundleInfo = BundleInfo(id: id, version: version, status: BundleStatus.ERROR, downloaded: Date(), checksum: checksum)
-            self.saveBundleInfo(id: id, bundle: info)
+            self.saveBundleInfo(id: id, bundle: BundleInfo(id: id, version: version, status: BundleStatus.ERROR, downloaded: Date(), checksum: checksum))
             throw mainError!
         }
         
         // If things completed successfully, mark the bundle status as success.
-        let info: BundleInfo = BundleInfo(id: id, version: version, status: BundleStatus.SUCCESS, downloaded: Date(), checksum: checksum)
-        self.saveBundleInfo(id: id, bundle: info)
+        self.saveBundleInfo(id: id, bundle: BundleInfo(id: id, version: version, status: BundleStatus.SUCCESS, downloaded: Date(), checksum: checksum))
         return info
     }
 

--- a/ios/Plugin/CapacitorUpdater.swift
+++ b/ios/Plugin/CapacitorUpdater.swift
@@ -486,9 +486,14 @@ extension CustomError: LocalizedError {
         self.notifyDownload(id, 0)
         semaphore.wait()
         if mainError != nil {
+            // If we hit an error, update the bundle info as errored
+            let info: BundleInfo = BundleInfo(id: id, version: version, status: BundleStatus.ERROR, downloaded: Date(), checksum: checksum)
+            self.saveBundleInfo(id: id, bundle: info)
             throw mainError!
         }
-        let info: BundleInfo = BundleInfo(id: id, version: version, status: BundleStatus.PENDING, downloaded: Date(), checksum: checksum)
+        
+        // If things completed successfully, mark the bundle status as success.
+        let info: BundleInfo = BundleInfo(id: id, version: version, status: BundleStatus.SUCCESS, downloaded: Date(), checksum: checksum)
         self.saveBundleInfo(id: id, bundle: info)
         return info
     }


### PR DESCRIPTION
Ive been seeing that bundles that are downloaded do not have the correct status, as they always report to me as "pending" though the bundle was successfully downloaded and can even be applied.
