### PR TITLE
fix: proguard usage

### DIFF
--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -19,3 +19,6 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Necessary for Gson Deserialization
+-keepattributes *Annotation*

--- a/android/src/main/java/ee/forgr/capacitor_updater/DelayCondition.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DelayCondition.java
@@ -6,11 +6,15 @@
 
 package ee.forgr.capacitor_updater;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.util.Objects;
 
 public class DelayCondition {
 
+  @SerializedName("kind")
   private DelayUntilNext kind;
+  @SerializedName("value")
   private String value;
 
   public DelayCondition(DelayUntilNext kind, String value) {


### PR DESCRIPTION
We recently decided to implement r8-proguard in our app.
To prevent errors in deobfuscation of json value we need to add @SerializedName annotation to the class field of serialized object, in this case, DelayCondition