### PR TITLE
Fix Android's notifyListeners "downloadComplete"

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -228,7 +228,8 @@ public class CapacitorUpdaterPlugin
       ret.put("bundle", bundleInfo.toJSON());
       this.notifyListeners("download", ret);
       if (percent == 100) {
-        this.notifyListeners("downloadComplete", bundleInfo.toJSON());
+        final JSObject retDownloadComplete = new JSObject(ret, new String[] {"bundle"});
+        this.notifyListeners("downloadComplete", retDownloadComplete);
         this.implementation.sendStats(
             "download_complete",
             bundleInfo.getVersionName()


### PR DESCRIPTION
Fix Android's notifyListeners "downloadComplete" so that it returns

```
{ "bundle":  { bundleInfo } }
```

instead of 

```
{ bundleInfo }
```