### PR TITLE
Fix iOS manual download blocking the main thread during unzipping

### DIFF
--- a/ios/Plugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Plugin/CapacitorUpdaterPlugin.swift
@@ -127,7 +127,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin {
         print("\(self.implementation.TAG) Downloading \(String(describing: url))")
         DispatchQueue.global(qos: .background).async {
             do {
-                let next = try self.implementation.download(url: url!, version: version, sessionKey: sessionKey)
+                let next = try self.implementation.downloadNonBlocking(url: url!, version: version, sessionKey: sessionKey)
                 if checksum != "" && next.getChecksum() != checksum {
                     print("\(self.implementation.TAG) Error checksum", next.getChecksum(), checksum)
                     self.implementation.sendStats(action: "checksum_fail", versionName: next.getVersionName())


### PR DESCRIPTION
Cap-go/capacitor-updater#221

Fix iOS manual download blocking the main thread during unzipping

I have no idea how Swift multi-threading works and the code is a product of my crude trial and error attempts. I cloned the `download()` function into `downloadNonBlocking()` in case this code breaks auto update mode (which I am currently unable to test).