### PR TITLE
Bugfix/ios initial revert to builtin

### DIFF
--- a/ios/Plugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Plugin/CapacitorUpdaterPlugin.swift
@@ -179,10 +179,15 @@ public class CapacitorUpdaterPlugin: CAPPlugin {
         guard let bridge = self.bridge else { return false }
         self.semaphoreUp()
         let id = self.implementation.getCurrentBundleId()
-        let destHot = self.implementation.getPathHot(id: id)
+        let dest : URL
+        if (BundleInfo.ID_BUILTIN == id) {
+            dest = Bundle.main.resourceURL!.appendingPathComponent("public")
+        } else {
+            dest = self.implementation.getPathHot(id: id)
+        }
         print("\(self.implementation.TAG) Reloading \(id)")
         if let vc = bridge.viewController as? CAPBridgeViewController {
-            vc.setServerBasePath(path: destHot.path)
+            vc.setServerBasePath(path: dest.path)
             self.checkAppReady()
             self.notifyListeners("appReloaded", data: [:])
             return true


### PR DESCRIPTION
This PR fixes an issue with the automatic webview reload after a failed update on iOS, specifically when the version it's trying to revert to is the `builtin` version.

When an app attempts an update for the first time and the new version doesn't call `notifyAppReady` after `appReadyTimeout` has been reached the plugin attempts to reload the webview. However, this fails when the version it's trying to revert to is the `builtin` version.

An error will be logged saying the webview cannot load `index.html` from `Documents/versions/builtin`. This would be because the `builtin` version doesn't exist there.

I initially tried calling `vc.setServerBasePath` with `nil`, but that didn't seem to work.

So instead I've implemented an approach of passing in the path to the public directory. This seems be what capacitor does by default: https://github.com/ionic-team/capacitor/blob/main/ios/Capacitor/Capacitor/CAPInstanceDescriptor.m#L17

I'm not a Swift programmer at all so please let me know if there's any issues with the approach taken.
Thank you for the awesome plugin!