### PR TITLE
Fix issue blocking publishing of the package

### DIFF
--- a/ios/Plugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Plugin/CapacitorUpdaterPlugin.swift
@@ -352,9 +352,9 @@ public class CapacitorUpdaterPlugin: CAPPlugin {
 
     @objc func notifyAppReady(_ call: CAPPluginCall) {
         self.semaphoreDown()
-        let version = self.implementation.getCurrentBundle()
-        self.implementation.setSuccess(bundle: version, autoDeletePrevious: self.autoDeletePrevious)
-        print("\(self.implementation.TAG) Current bundle loaded successfully. ['notifyAppReady()' was called] \(version.toString())")
+        let bundle = self.implementation.getCurrentBundle()
+        self.implementation.setSuccess(bundle: bundle, autoDeletePrevious: self.autoDeletePrevious)
+        print("\(self.implementation.TAG) Current bundle loaded successfully. ['notifyAppReady()' was called] \(bundle.toString())")
         call.resolve(["bundle": bundle.toJSON()])
     }
 


### PR DESCRIPTION
Looks like a change was introduced in [5.2.23](https://github.com/Cap-go/capacitor-updater/compare/5.2.22...5.2.23) which is blocking publishing of the package to NPM due to an iOS bug.

Thanks again for an awesome plugin!