### PR TITLE
Run fmt to prettify typescript

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -104,9 +104,9 @@ export class CapacitorUpdaterWeb
       error: "Cannot getChannel in web",
     };
   }
-  async notifyAppReady(): Promise<{bundle: BundleInfo}> {
+  async notifyAppReady(): Promise<{ bundle: BundleInfo }> {
     console.warn("Cannot notify App Ready in web");
-    return {bundle: BUNDLE_BUILTIN};
+    return { bundle: BUNDLE_BUILTIN };
   }
   async setMultiDelay(options: {
     delayConditions: DelayCondition[];


### PR DESCRIPTION
Looks like the [publishing still failed due to prettier check](https://github.com/Cap-go/capacitor-updater/actions/runs/6005941656/job/16289714487). I ran `npm run fmt` on my local and I believe it should pass now.