### PR TITLE
#87 - implemented I18n localization for android and iOS

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
@@ -71,6 +71,8 @@ public class CapacitorUpdater {
 
   public static final String TAG = "Capacitor-updater";
 
+  public static int timeout = 20000;
+
   public SharedPreferences.Editor editor;
   public SharedPreferences prefs;
 

--- a/ios/Plugin/CapacitorUpdater.swift
+++ b/ios/Plugin/CapacitorUpdater.swift
@@ -235,7 +235,9 @@ extension CustomError: LocalizedError {
     public var versionBuild: String = ""
     public var customId: String = ""
     public var PLUGIN_VERSION: String = ""
-    public var timeout: Double = 20
+
+    public var timeout: Int = 20
+
     public var statsUrl: String = ""
     public var channelUrl: String = ""
     public var appId: String = ""

--- a/ios/Plugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Plugin/CapacitorUpdaterPlugin.swift
@@ -145,12 +145,12 @@ public class CapacitorUpdaterPlugin: CAPPlugin {
     @objc func download(_ call: CAPPluginCall) {
         guard let urlString = call.getString("url") else {
             print("\(self.implementation.TAG) Download called without url")
-            call.reject("Download called without url")
+            call.reject(NSLocalizedString("downloadWithoutURL", comment: ""))
             return
         }
         guard let version = call.getString("version") else {
             print("\(self.implementation.TAG) Download called without version")
-            call.reject("Download called without version")
+            call.reject(NSLocalizedString("downloadWithoutVersion", comment: ""))
             return
         }
         let sessionKey = call.getString("sessionKey", "")
@@ -177,7 +177,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin {
                 self.notifyListeners("downloadFailed", data: ["version": version])
                 let current: BundleInfo = self.implementation.getCurrentBundle()
                 self.implementation.sendStats(action: "download_fail", versionName: current.getVersionName())
-                call.reject("Failed to download from: \(url!)", error.localizedDescription)
+                call.reject(NSLocalizedString("failedToDownload", comment: "")+url, error.localizedDescription)
             }
         }
     }
@@ -207,20 +207,20 @@ public class CapacitorUpdaterPlugin: CAPPlugin {
             call.resolve()
         } else {
             print("\(self.implementation.TAG) Reload failed")
-            call.reject("Reload failed")
+            call.reject(NSLocalizedString("reloadFailed", comment: ""))
         }
     }
 
     @objc func next(_ call: CAPPluginCall) {
         guard let id = call.getString("id") else {
             print("\(self.implementation.TAG) Next called without id")
-            call.reject("Next called without id")
+            call.reject(NSLocalizedString("nextWithoutId", comment: ""))
             return
         }
         print("\(self.implementation.TAG) Setting next active id \(id)")
         if !self.implementation.setNextBundle(next: id) {
             print("\(self.implementation.TAG) Set next version failed. id \(id) does not exist.")
-            call.reject("Set next version failed. id \(id) does not exist.")
+            call.reject(NSLocalizedString("setNextFailed", comment: "")+id+NSLocalizedString("doesNotExist", comment: ""))
         } else {
             call.resolve(self.implementation.getBundleInfo(id: id).toJSON())
         }
@@ -229,14 +229,14 @@ public class CapacitorUpdaterPlugin: CAPPlugin {
     @objc func set(_ call: CAPPluginCall) {
         guard let id = call.getString("id") else {
             print("\(self.implementation.TAG) Set called without id")
-            call.reject("Set called without id")
+            call.reject(NSLocalizedString("setWithoutId", comment: ""))
             return
         }
         let res = implementation.set(id: id)
         print("\(self.implementation.TAG) Set active bundle: \(id)")
         if !res {
             print("\(self.implementation.TAG) Bundle successfully set to: \(id) ")
-            call.reject("Update failed, id \(id) doesn't exist")
+            call.reject(NSLocalizedString("updateFailed", comment: "")+id+NSLocalizedString("doesNotExist"))
         } else {
             self.reload(call)
         }
@@ -245,7 +245,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin {
     @objc func delete(_ call: CAPPluginCall) {
         guard let id = call.getString("id") else {
             print("\(self.implementation.TAG) Delete called without version")
-            call.reject("Delete called without id")
+            call.reject(NSLocalizedString("deleteWithoutId", comment: ""))
             return
         }
         let res = implementation.delete(id: id)
@@ -253,7 +253,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin {
             call.resolve()
         } else {
             print("\(self.implementation.TAG) Delete failed, id \(id) doesn't exist")
-            call.reject("Delete failed, id \(id) doesn't exist")
+            call.reject(NSLocalizedString("deleteFailed", comment: "")+id+NSLocalizedString("doesNotExist", comment: ""))
         }
     }
 
@@ -300,7 +300,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin {
     @objc func setChannel(_ call: CAPPluginCall) {
         guard let channel = call.getString("channel") else {
             print("\(self.implementation.TAG) setChannel called without channel")
-            call.reject("setChannel called without channel")
+            call.reject(NSLocalizedString("setChannelCalled", comment: ""))
             return
         }
         let triggerAutoUpdate = call.getBool("triggerAutoUpdate") ?? false
@@ -331,7 +331,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin {
     @objc func setCustomId(_ call: CAPPluginCall) {
         guard let customId = call.getString("customId") else {
             print("\(self.implementation.TAG) setCustomId called without customId")
-            call.reject("setCustomId called without customId")
+            call.reject(NSLocalizedString("setCustomIdCalled", comment: ""))
             return
         }
         self.implementation.customId = customId
@@ -366,7 +366,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin {
             call.resolve()
         } else {
             print("\(self.implementation.TAG) Reset failed")
-            call.reject("\(self.implementation.TAG) Reset failed")
+            call.reject(self.implementation.TAG+NSLocalizedString("resetFailed", comment: ""))
         }
     }
 
@@ -389,14 +389,14 @@ public class CapacitorUpdaterPlugin: CAPPlugin {
     @objc func setMultiDelay(_ call: CAPPluginCall) {
         guard let delayConditionList = call.getValue("delayConditions") else {
             print("\(self.implementation.TAG) setMultiDelay called without delayCondition")
-            call.reject("setMultiDelay called without delayCondition")
+            call.reject(NSLocalizedString("setMultiDelayCalled", comment: ""))
             return
         }
         let delayConditions: String = toJson(object: delayConditionList)
         if _setMultiDelay(delayConditions: delayConditions) {
             call.resolve()
         } else {
-            call.reject("Failed to delay update")
+            call.reject(NSLocalizedString("failedToDelayUpdate", comment: ""))
         }
     }
 


### PR DESCRIPTION
/claim #87 
I18n localization for android and iOS has been implemented.

## For Android:
1. The key-value pairs for localizations can be found in res/values-<language_code>/strings.xml
2. The file res/values/strings.xml is the fallback file. If the user selects any language that is not implemented by us, the values from this file are used.
3. These strings can be used in the app using Resources.getSystem().getString(R.string.<name_property>). For eg: Resources.getSystem().getString(R.string.hello_world)
4. New languages can be added by simple creating new folder like in: res/values-<language_code>/strings.xml and inserting all the translated strings.

## For iOS:
1. The key-value pairs for localizations can be found in Localizable in the left navigation pane.
2. Each language uses a separate file named as Localizable (language) in the left navigation pane.
3. The strings can be accessed by: NSLocalizedString(<key_name>, comment:""). For example: NSLocalizedString("hello_world", comment:"").
4. New languages can be added by doing the following in XCode: `Plugin (in the left navigation pane) -> Plugin (Project) -> Info -> Localizations -> Press (+) -> Select language

_For both android and iOS, the keys of all the translated matching strings should match. Else the translations will not work._