### PR TITLE
Fix kill delay being triggered on Android when returning from background

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -1373,7 +1373,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
         "app_moved_to_foreground",
         current.getVersionName()
       );
-    this._checkCancelDelay(true);
+    this._checkCancelDelay(false);
     if (
       CapacitorUpdaterPlugin.this._isAutoUpdateEnabled() &&
       this.backgroundDownloadTask == null


### PR DESCRIPTION
Thanks for this great plugin! I've found a small issue which this PR fixes.

Today I was setting up my app to use `setMultiDelay` so the app doesn't reload in the background if the user is on a screen where they have unsaved data. I set it up to only reload if the app has been killed:

```
CapacitorUpdater.setMultiDelay({
  delayConditions: [{ kind: 'kill' }],
});
```

In my testing, iOS worked as expected, but on Android the app reloaded when going into the background (technically due to this bug, the app reloads when it resumes, rather than when it goes into the background). Looking through the logs, I found that the app thought it was resuming from being killed rather than just being in the background.

It seems to be down to a typo in the `appMovedToForeground` method, where `this._checkCancelDelay` is called with `true`, meaning the app was killed. However, `appMovedToForeground` is only ever called if the activity is started and `isPreviousMainActivity` is true, meaning it will never be resuming from being killed. If it had been killed, `isPreviousMainActivity` would be false.

So, this PR fixes the issue by changing the argument to `this._checkCancelDelay` to be `false` instead. In my testing it now works as expected.