### PR TITLE
fix: android opening two download stream of the bundle

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
@@ -450,7 +450,7 @@ public class CapacitorUpdater {
     int percent = 0;
     this.notifyDownload(id, 10);
     try (
-      final InputStream is = u.openStream();
+      final InputStream is = connection.getInputStream();
       final DataInputStream dis = new DataInputStream(is);
       final FileOutputStream fos = new FileOutputStream(target)
     ) {


### PR DESCRIPTION
When calling `u.openStream();` the bundle starts downloading again because of the stream has already open on 9th line above in the `connection.getContentLength();`

I noticed this because I implemented a strict policy on my CDN. I only accept one Bundle download per Device every 3 seconds, then I return HTTP 429. As I started to receive a lot of update errors I went to investigate.

Navigating Step Into with Android Debug I noticed that two streams were open at the same time, which is why the first HTTP request to obtain the bundle size worked and the second did not. I found this article that helped resolve the issue:

https://stackoverflow.com/questions/38583020/httpurlconnection-request-being-hit-twice-to-the-server-for-downloading-file