### PR TITLE
Switch E2E key type to increase security

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ CapacitorUpdater can be configured with this options:
 | **`resetWhenUpdate`**    | <code>boolean</code> | Automatically delete previous downloaded bundles when a newer native app bundle is installed to the device. Only available for Android and iOS.                                                 | <code>true</code>                              |         |
 | **`updateUrl`**          | <code>string</code>  | Configure the URL / endpoint to which update checks are sent. Only available for Android and iOS.                                                                                               | <code>https://api.capgo.app/auto_update</code> |         |
 | **`statsUrl`**           | <code>string</code>  | Configure the URL / endpoint to which update statistics are sent. Only available for Android and iOS. Set to "" to disable stats reporting.                                                     | <code>https://api.capgo.app/stats</code>       |         |
-| **`privateKey`**         | <code>string</code>  | Configure the private key for end to end live update encryption. Only available for Android and iOS.                                                                                            | <code>undefined</code>                         |         |
+| **`publicKey`**          | <code>string</code>  | Configure the public key for end to end live update encryption. Only available for Android and iOS.                                                                                             | <code>undefined</code>                         |         |
 | **`version`**            | <code>string</code>  | Configure the current version of the app. This will be used for the first update request. If not set, the plugin will get the version from the native code. Only available for Android and iOS. | <code>undefined</code>                         | 4.17.48 |
 | **`directUpdate`**       | <code>boolean</code> | Make the plugin direct install the update when the app what just updated/installed. Only for autoUpdate mode. Only available for Android and iOS.                                               | <code>undefined</code>                         | 5.1.0   |
 | **`periodCheckDelay`**   | <code>number</code>  | Configure the delay period for period update check. the unit is in seconds. Only available for Android and iOS. Cannot be less than 600 seconds (10 minutes).                                   | <code>600 // (10 minutes)</code>               |         |
@@ -193,7 +193,7 @@ In `capacitor.config.json`:
       "resetWhenUpdate": false,
       "updateUrl": https://example.com/api/auto_update,
       "statsUrl": https://example.com/api/stats,
-      "privateKey": undefined,
+      "publicKey": undefined,
       "version": undefined,
       "directUpdate": undefined,
       "periodCheckDelay": undefined,
@@ -227,7 +227,7 @@ const config: CapacitorConfig = {
       resetWhenUpdate: false,
       updateUrl: https://example.com/api/auto_update,
       statsUrl: https://example.com/api/stats,
-      privateKey: undefined,
+      publicKey: undefined,
       version: undefined,
       directUpdate: undefined,
       periodCheckDelay: undefined,

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -50,11 +50,9 @@ public class CapacitorUpdaterPlugin extends Plugin {
   private static final String updateUrlDefault =
     "https://api.capgo.app/updates";
   private static final String statsUrlDefault = "https://api.capgo.app/stats";
-  private static final String defaultPrivateKey =
-    "-----BEGIN RSA PRIVATE KEY-----\nMIIEpQIBAAKCAQEA4pW9olT0FBXXivRCzd3xcImlWZrqkwcF2xTkX/FwXmj9eh9H\nkBLrsQmfsC+PJisRXIOGq6a0z3bsGq6jBpp3/Jr9jiaW5VuPGaKeMaZZBRvi/N5f\nIMG3hZXSOcy0IYg+E1Q7RkYO1xq5GLHseqG+PXvJsNe4R8R/Bmd/ngq0xh/cvcrH\nHpXwO0Aj9tfprlb+rHaVV79EkVRWYPidOLnK1n0EFHFJ1d/MyDIp10TEGm2xHpf/\nBrlb1an8wXEuzoC0DgYaczgTjovwR+ewSGhSHJliQdM0Qa3o1iN87DldWtydImMs\nPjJ3DUwpsjAMRe5X8Et4+udFW2ciYnQo9H0CkwIDAQABAoIBAQCtjlMV/4qBxAU4\nu0ZcWA9yywwraX0aJ3v1xrfzQYV322Wk4Ea5dbSxA5UcqCE29DA1M824t1Wxv/6z\npWbcTP9xLuresnJMtmgTE7umfiubvTONy2sENT20hgDkIwcq1CfwOEm61zjQzPhQ\nkSB5AmEsyR/BZEsUNc+ygR6AWOUFB7tj4yMc32LOTWSbE/znnF2BkmlmnQykomG1\n2oVqM3lUFP7+m8ux1O7scO6IMts+Z/eFXjWfxpbebUSvSIR83GXPQZ34S/c0ehOg\nyHdmCSOel1r3VvInMe+30j54Jr+Ml/7Ee6axiwyE2e/bd85MsK9sVdp0OtelXaqA\nOZZqWvN5AoGBAP2Hn3lSq+a8GsDH726mHJw60xM0LPbVJTYbXsmQkg1tl3NKJTMM\nQqz41+5uys+phEgLHI9gVJ0r+HaGHXnJ4zewlFjsudstb/0nfctUvTqnhEhfNo9I\ny4kufVKPRF3sMEeo7CDVJs4GNBLycEyIBy6Mbv0VcO7VaZqggRwu4no9AoGBAOTK\n6NWYs1BWlkua2wmxexGOzehNGedInp0wGr2l4FDayWjkZLqvB+nNXUQ63NdHlSs4\nWB2Z1kQXZxVaI2tPYexGUKXEo2uFob63uflbuE029ovDXIIPFTPtGNdNXwhHT5a+\nPhmy3sMc+s2BSNM5qaNmfxQxhdd6gRU6oikE+c0PAoGAMn3cKNFqIt27hkFLUgIL\nGKIuf1iYy9/PNWNmEUaVj88PpopRtkTu0nwMpROzmH/uNFriKTvKHjMvnItBO4wV\nkHW+VadvrFL0Rrqituf9d7z8/1zXBNo+juePVe3qc7oiM2NVA4Tv4YAixtM5wkQl\nCgQ15nlqsGYYTg9BJ1e/CxECgYEAjEYPzO2reuUrjr0p8F59ev1YJ0YmTJRMk0ks\nC/yIdGo/tGzbiU3JB0LfHPcN8Xu07GPGOpfYM7U5gXDbaG6qNgfCaHAQVdr/mQPi\nJQ1kCQtay8QCkscWk9iZM1//lP7LwDtxraXqSCwbZSYP9VlUNZeg8EuQqNU2EUL6\nqzWexmcCgYEA0prUGNBacraTYEknB1CsbP36UPWsqFWOvevlz+uEC5JPxPuW5ZHh\nSQN7xl6+PHyjPBM7ttwPKyhgLOVTb3K7ex/PXnudojMUK5fh7vYfChVTSlx2p6r0\nDi58PdD+node08cJH+ie0Yphp7m+D4+R9XD0v0nEvnu4BtAW6DrJasw=\n-----END RSA PRIVATE KEY-----\n";
   private static final String defaultPublicKey =
     "-----BEGIN RSA PUBLIC KEY-----\nMIIBCgKCAQEA4pW9olT0FBXXivRCzd3xcImlWZrqkwcF2xTkX/FwXmj9eh9HkBLr\nsQmfsC+PJisRXIOGq6a0z3bsGq6jBpp3/Jr9jiaW5VuPGaKeMaZZBRvi/N5fIMG3\nhZXSOcy0IYg+E1Q7RkYO1xq5GLHseqG+PXvJsNe4R8R/Bmd/ngq0xh/cvcrHHpXw\nO0Aj9tfprlb+rHaVV79EkVRWYPidOLnK1n0EFHFJ1d/MyDIp10TEGm2xHpf/Brlb\n1an8wXEuzoC0DgYaczgTjovwR+ewSGhSHJliQdM0Qa3o1iN87DldWtydImMsPjJ3\nDUwpsjAMRe5X8Et4+udFW2ciYnQo9H0CkwIDAQAB\n-----END RSA PUBLIC KEY-----\n";
-    private static final String channelUrlDefault =
+  private static final String channelUrlDefault =
     "https://api.capgo.app/channel_self";
 
   private final String PLUGIN_VERSION = "5.6.8";
@@ -177,10 +175,16 @@ public class CapacitorUpdaterPlugin extends Plugin {
       );
     }
     Log.i(CapacitorUpdater.TAG, "appId: " + implementation.appId);
-    this.implementation.privateKey =
-      this.getConfig().getString("privateKey", defaultPrivateKey);
+    Gson gson = new Gson();
     this.implementation.publicKey =
-      this.getConfig().getString("publicKey", defaultPublicKey);
+      getConfig().getString("publicKey", defaultPublicKey);
+    this.implementation.hasOldPrivateKeyPropertyInConfig = false;
+    if (
+      this.getConfig().getString("privateKey") != null &&
+      !this.getConfig().getString("privateKey").isEmpty()
+    ) {
+      this.implementation.hasOldPrivateKeyPropertyInConfig = true;
+    }
     this.implementation.statsUrl =
       this.getConfig().getString("statsUrl", statsUrlDefault);
     this.implementation.channelUrl =

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -175,7 +175,6 @@ public class CapacitorUpdaterPlugin extends Plugin {
       );
     }
     Log.i(CapacitorUpdater.TAG, "appId: " + implementation.appId);
-    Gson gson = new Gson();
     this.implementation.publicKey =
       getConfig().getString("publicKey", defaultPublicKey);
     this.implementation.hasOldPrivateKeyPropertyInConfig = false;

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -52,7 +52,9 @@ public class CapacitorUpdaterPlugin extends Plugin {
   private static final String statsUrlDefault = "https://api.capgo.app/stats";
   private static final String defaultPrivateKey =
     "-----BEGIN RSA PRIVATE KEY-----\nMIIEpQIBAAKCAQEA4pW9olT0FBXXivRCzd3xcImlWZrqkwcF2xTkX/FwXmj9eh9H\nkBLrsQmfsC+PJisRXIOGq6a0z3bsGq6jBpp3/Jr9jiaW5VuPGaKeMaZZBRvi/N5f\nIMG3hZXSOcy0IYg+E1Q7RkYO1xq5GLHseqG+PXvJsNe4R8R/Bmd/ngq0xh/cvcrH\nHpXwO0Aj9tfprlb+rHaVV79EkVRWYPidOLnK1n0EFHFJ1d/MyDIp10TEGm2xHpf/\nBrlb1an8wXEuzoC0DgYaczgTjovwR+ewSGhSHJliQdM0Qa3o1iN87DldWtydImMs\nPjJ3DUwpsjAMRe5X8Et4+udFW2ciYnQo9H0CkwIDAQABAoIBAQCtjlMV/4qBxAU4\nu0ZcWA9yywwraX0aJ3v1xrfzQYV322Wk4Ea5dbSxA5UcqCE29DA1M824t1Wxv/6z\npWbcTP9xLuresnJMtmgTE7umfiubvTONy2sENT20hgDkIwcq1CfwOEm61zjQzPhQ\nkSB5AmEsyR/BZEsUNc+ygR6AWOUFB7tj4yMc32LOTWSbE/znnF2BkmlmnQykomG1\n2oVqM3lUFP7+m8ux1O7scO6IMts+Z/eFXjWfxpbebUSvSIR83GXPQZ34S/c0ehOg\nyHdmCSOel1r3VvInMe+30j54Jr+Ml/7Ee6axiwyE2e/bd85MsK9sVdp0OtelXaqA\nOZZqWvN5AoGBAP2Hn3lSq+a8GsDH726mHJw60xM0LPbVJTYbXsmQkg1tl3NKJTMM\nQqz41+5uys+phEgLHI9gVJ0r+HaGHXnJ4zewlFjsudstb/0nfctUvTqnhEhfNo9I\ny4kufVKPRF3sMEeo7CDVJs4GNBLycEyIBy6Mbv0VcO7VaZqggRwu4no9AoGBAOTK\n6NWYs1BWlkua2wmxexGOzehNGedInp0wGr2l4FDayWjkZLqvB+nNXUQ63NdHlSs4\nWB2Z1kQXZxVaI2tPYexGUKXEo2uFob63uflbuE029ovDXIIPFTPtGNdNXwhHT5a+\nPhmy3sMc+s2BSNM5qaNmfxQxhdd6gRU6oikE+c0PAoGAMn3cKNFqIt27hkFLUgIL\nGKIuf1iYy9/PNWNmEUaVj88PpopRtkTu0nwMpROzmH/uNFriKTvKHjMvnItBO4wV\nkHW+VadvrFL0Rrqituf9d7z8/1zXBNo+juePVe3qc7oiM2NVA4Tv4YAixtM5wkQl\nCgQ15nlqsGYYTg9BJ1e/CxECgYEAjEYPzO2reuUrjr0p8F59ev1YJ0YmTJRMk0ks\nC/yIdGo/tGzbiU3JB0LfHPcN8Xu07GPGOpfYM7U5gXDbaG6qNgfCaHAQVdr/mQPi\nJQ1kCQtay8QCkscWk9iZM1//lP7LwDtxraXqSCwbZSYP9VlUNZeg8EuQqNU2EUL6\nqzWexmcCgYEA0prUGNBacraTYEknB1CsbP36UPWsqFWOvevlz+uEC5JPxPuW5ZHh\nSQN7xl6+PHyjPBM7ttwPKyhgLOVTb3K7ex/PXnudojMUK5fh7vYfChVTSlx2p6r0\nDi58PdD+node08cJH+ie0Yphp7m+D4+R9XD0v0nEvnu4BtAW6DrJasw=\n-----END RSA PRIVATE KEY-----\n";
-  private static final String channelUrlDefault =
+  private static final String defaultPublicKey =
+    "-----BEGIN RSA PUBLIC KEY-----\nMIIBCgKCAQEA4pW9olT0FBXXivRCzd3xcImlWZrqkwcF2xTkX/FwXmj9eh9HkBLr\nsQmfsC+PJisRXIOGq6a0z3bsGq6jBpp3/Jr9jiaW5VuPGaKeMaZZBRvi/N5fIMG3\nhZXSOcy0IYg+E1Q7RkYO1xq5GLHseqG+PXvJsNe4R8R/Bmd/ngq0xh/cvcrHHpXw\nO0Aj9tfprlb+rHaVV79EkVRWYPidOLnK1n0EFHFJ1d/MyDIp10TEGm2xHpf/Brlb\n1an8wXEuzoC0DgYaczgTjovwR+ewSGhSHJliQdM0Qa3o1iN87DldWtydImMsPjJ3\nDUwpsjAMRe5X8Et4+udFW2ciYnQo9H0CkwIDAQAB\n-----END RSA PUBLIC KEY-----\n";
+    private static final String channelUrlDefault =
     "https://api.capgo.app/channel_self";
 
   private final String PLUGIN_VERSION = "5.6.8";
@@ -177,6 +179,8 @@ public class CapacitorUpdaterPlugin extends Plugin {
     Log.i(CapacitorUpdater.TAG, "appId: " + implementation.appId);
     this.implementation.privateKey =
       this.getConfig().getString("privateKey", defaultPrivateKey);
+    this.implementation.publicKey =
+      this.getConfig().getString("publicKey", defaultPublicKey);
     this.implementation.statsUrl =
       this.getConfig().getString("statsUrl", statsUrlDefault);
     this.implementation.channelUrl =

--- a/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
@@ -19,8 +19,6 @@ import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
-// import java.security.spec.MGF1ParameterSpec;
-// import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -28,7 +26,6 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
-// import javax.crypto.spec.OAEPParameterSpec;
 import javax.crypto.spec.PSource;
 import javax.crypto.spec.SecretKeySpec;
 

--- a/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
@@ -18,14 +18,16 @@ import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
-import javax.crypto.SecretKey;
+import javax.crypto.SecretKey;  
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.OAEPParameterSpec;
 import javax.crypto.spec.PSource;
@@ -149,5 +151,124 @@ public class CryptoCipher {
     );
     // extract the private key
     return readPkcs1PrivateKey(pkcs1EncodedBytes);
+  }
+
+  public static byte[] decryptPublicRSA(byte[] source, PublicKey publicKey)
+    throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
+    Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
+    cipher.init(Cipher.DECRYPT_MODE, publicKey);
+    byte[] decryptedBytes = cipher.doFinal(source);
+    return decryptedBytes;
+  }
+
+  private static PublicKey readX509PublicKey(byte[] pkcs8Bytes)
+    throws GeneralSecurityException {
+    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+    X509EncodedKeySpec keySpec = new X509EncodedKeySpec(pkcs8Bytes);
+    try {
+      return keyFactory.generatePublic(keySpec);
+    } catch (InvalidKeySpecException e) {
+      throw new IllegalArgumentException("Unexpected key format!", e);
+    }
+  }
+
+  public static PublicKey stringToPublicKey(String public_key)
+    throws GeneralSecurityException {
+    // Base64 decode the result
+
+    String pkcs1Pem = public_key.toString();
+    pkcs1Pem = pkcs1Pem.replace("-----BEGIN RSA PUBLIC KEY-----", "");
+    pkcs1Pem = pkcs1Pem.replace("-----END RSA PUBLIC KEY-----", "");
+    pkcs1Pem = pkcs1Pem.replace("\n", "");
+    pkcs1Pem = pkcs1Pem.replace(" ", "");
+
+    byte[] pkcs1EncodedBytes = Base64.decode(
+      pkcs1Pem,
+      Base64.DEFAULT
+    );
+
+    // extract the public key
+    return readPkcs1PublicKey(pkcs1EncodedBytes);
+  }
+
+  // since the public key is in pkcs1 format, we have to convert it to x509 format similar
+  // to what needs done with the private key converting to pkcs8 format
+  // so, the rest of the code below here is adapted from here https://stackoverflow.com/a/54246646
+  private static final int SEQUENCE_TAG = 0x30;
+  private static final int BIT_STRING_TAG = 0x03;
+  private static final byte[] NO_UNUSED_BITS = new byte[] { 0x00 };
+  private static final byte[] RSA_ALGORITHM_IDENTIFIER_SEQUENCE =
+    {(byte) 0x30, (byte) 0x0d,
+            (byte) 0x06, (byte) 0x09, (byte) 0x2a, (byte) 0x86, (byte) 0x48, (byte) 0x86, (byte) 0xf7, (byte) 0x0d, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+            (byte) 0x05, (byte) 0x00};
+
+  private static PublicKey readPkcs1PublicKey(byte[] pkcs1Bytes)
+    throws NoSuchAlgorithmException, InvalidKeySpecException, GeneralSecurityException {
+    // convert the pkcs1 public key to an x509 favorable format
+    byte[] keyBitString = createDEREncoding(BIT_STRING_TAG, joinPublic(NO_UNUSED_BITS, pkcs1Bytes));
+    byte[] keyInfoValue = joinPublic(RSA_ALGORITHM_IDENTIFIER_SEQUENCE, keyBitString);
+    byte[] keyInfoSequence = createDEREncoding(SEQUENCE_TAG, keyInfoValue);
+    return readX509PublicKey(keyInfoSequence);
+  }
+
+  private static byte[] joinPublic(byte[] ... bas)
+  {
+      int len = 0;
+      for (int i = 0; i < bas.length; i++)
+      {
+          len += bas[i].length;
+      }
+
+      byte[] buf = new byte[len];
+      int off = 0;
+      for (int i = 0; i < bas.length; i++)
+      {
+          System.arraycopy(bas[i], 0, buf, off, bas[i].length);
+          off += bas[i].length;
+      }
+
+      return buf;
+  }
+
+  private static byte[] createDEREncoding(int tag, byte[] value)
+  {
+      if (tag < 0 || tag >= 0xFF)
+      {
+          throw new IllegalArgumentException("Currently only single byte tags supported");
+      }
+
+      byte[] lengthEncoding = createDERLengthEncoding(value.length);
+
+      int size = 1 + lengthEncoding.length + value.length;
+      byte[] derEncodingBuf = new byte[size];
+
+      int off = 0;
+      derEncodingBuf[off++] = (byte) tag;
+      System.arraycopy(lengthEncoding, 0, derEncodingBuf, off, lengthEncoding.length);
+      off += lengthEncoding.length;
+      System.arraycopy(value, 0, derEncodingBuf, off, value.length);
+
+      return derEncodingBuf;
+  }   
+
+  private static byte[] createDERLengthEncoding(int size)
+  {
+      if (size <= 0x7F)
+      {
+          // single byte length encoding
+          return new byte[] { (byte) size };
+      }
+      else if (size <= 0xFF)
+      {
+          // double byte length encoding
+          return new byte[] { (byte) 0x81, (byte) size };
+      }
+      else if (size <= 0xFFFF)
+      {
+          // triple byte length encoding
+          return new byte[] { (byte) 0x82, (byte) (size >> Byte.SIZE), (byte) size };
+      }
+
+      throw new IllegalArgumentException("size too large, only up to 64KiB length encoding supported: " + size);
   }
 }

--- a/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
@@ -17,34 +17,27 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
-import java.security.spec.MGF1ParameterSpec;
-import java.security.spec.PKCS8EncodedKeySpec;
+// import java.security.spec.MGF1ParameterSpec;
+// import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
-import javax.crypto.SecretKey;  
+import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
-import javax.crypto.spec.OAEPParameterSpec;
+// import javax.crypto.spec.OAEPParameterSpec;
 import javax.crypto.spec.PSource;
 import javax.crypto.spec.SecretKeySpec;
 
 public class CryptoCipher {
 
-  public static byte[] decryptRSA(byte[] source, PrivateKey privateKey)
+  public static byte[] decryptRSA(byte[] source, PublicKey publicKey)
     throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
-    Cipher cipher = Cipher.getInstance("RSA/ECB/OAEPPadding");
-    OAEPParameterSpec oaepParams = new OAEPParameterSpec(
-      "SHA-256",
-      "MGF1",
-      new MGF1ParameterSpec("SHA-256"),
-      PSource.PSpecified.DEFAULT
-    );
-    cipher.init(Cipher.DECRYPT_MODE, privateKey, oaepParams);
+    Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
+    cipher.init(Cipher.DECRYPT_MODE, publicKey);
     byte[] decryptedBytes = cipher.doFinal(source);
     return decryptedBytes;
   }
@@ -74,97 +67,10 @@ public class CryptoCipher {
     return originalKey;
   }
 
-  private static PrivateKey readPkcs8PrivateKey(byte[] pkcs8Bytes)
+  private static PublicKey readX509PublicKey(byte[] x509Bytes)
     throws GeneralSecurityException {
     KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-    PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(pkcs8Bytes);
-    try {
-      return keyFactory.generatePrivate(keySpec);
-    } catch (InvalidKeySpecException e) {
-      throw new IllegalArgumentException("Unexpected key format!", e);
-    }
-  }
-
-  private static byte[] join(byte[] byteArray1, byte[] byteArray2) {
-    byte[] bytes = new byte[byteArray1.length + byteArray2.length];
-    System.arraycopy(byteArray1, 0, bytes, 0, byteArray1.length);
-    System.arraycopy(
-      byteArray2,
-      0,
-      bytes,
-      byteArray1.length,
-      byteArray2.length
-    );
-    return bytes;
-  }
-
-  private static PrivateKey readPkcs1PrivateKey(byte[] pkcs1Bytes)
-    throws GeneralSecurityException {
-    // We can't use Java internal APIs to parse ASN.1 structures, so we build a PKCS#8 key Java can understand
-    int pkcs1Length = pkcs1Bytes.length;
-    int totalLength = pkcs1Length + 22;
-    byte[] pkcs8Header = new byte[] {
-      0x30,
-      (byte) 0x82,
-      (byte) ((totalLength >> 8) & 0xff),
-      (byte) (totalLength & 0xff), // Sequence + total length
-      0x2,
-      0x1,
-      0x0, // Integer (0)
-      0x30,
-      0xD,
-      0x6,
-      0x9,
-      0x2A,
-      (byte) 0x86,
-      0x48,
-      (byte) 0x86,
-      (byte) 0xF7,
-      0xD,
-      0x1,
-      0x1,
-      0x1,
-      0x5,
-      0x0, // Sequence: 1.2.840.113549.1.1.1, NULL
-      0x4,
-      (byte) 0x82,
-      (byte) ((pkcs1Length >> 8) & 0xff),
-      (byte) (pkcs1Length & 0xff), // Octet string + length
-    };
-    byte[] pkcs8bytes = join(pkcs8Header, pkcs1Bytes);
-    return readPkcs8PrivateKey(pkcs8bytes);
-  }
-
-  public static PrivateKey stringToPrivateKey(String private_key)
-    throws GeneralSecurityException {
-    // Base64 decode the result
-
-    String pkcs1Pem = private_key.toString();
-    pkcs1Pem = pkcs1Pem.replace("-----BEGIN RSA PRIVATE KEY-----", "");
-    pkcs1Pem = pkcs1Pem.replace("-----END RSA PRIVATE KEY-----", "");
-    pkcs1Pem = pkcs1Pem.replace("\\n", "");
-    pkcs1Pem = pkcs1Pem.replace(" ", "");
-
-    byte[] pkcs1EncodedBytes = Base64.decode(
-      pkcs1Pem.getBytes(),
-      Base64.DEFAULT
-    );
-    // extract the private key
-    return readPkcs1PrivateKey(pkcs1EncodedBytes);
-  }
-
-  public static byte[] decryptPublicRSA(byte[] source, PublicKey publicKey)
-    throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
-    Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
-    cipher.init(Cipher.DECRYPT_MODE, publicKey);
-    byte[] decryptedBytes = cipher.doFinal(source);
-    return decryptedBytes;
-  }
-
-  private static PublicKey readX509PublicKey(byte[] pkcs8Bytes)
-    throws GeneralSecurityException {
-    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-    X509EncodedKeySpec keySpec = new X509EncodedKeySpec(pkcs8Bytes);
+    X509EncodedKeySpec keySpec = new X509EncodedKeySpec(x509Bytes);
     try {
       return keyFactory.generatePublic(keySpec);
     } catch (InvalidKeySpecException e) {
@@ -179,13 +85,10 @@ public class CryptoCipher {
     String pkcs1Pem = public_key.toString();
     pkcs1Pem = pkcs1Pem.replace("-----BEGIN RSA PUBLIC KEY-----", "");
     pkcs1Pem = pkcs1Pem.replace("-----END RSA PUBLIC KEY-----", "");
-    pkcs1Pem = pkcs1Pem.replace("\n", "");
+    pkcs1Pem = pkcs1Pem.replace("\\n", "");
     pkcs1Pem = pkcs1Pem.replace(" ", "");
 
-    byte[] pkcs1EncodedBytes = Base64.decode(
-      pkcs1Pem,
-      Base64.DEFAULT
-    );
+    byte[] pkcs1EncodedBytes = Base64.decode(pkcs1Pem, Base64.DEFAULT);
 
     // extract the public key
     return readPkcs1PublicKey(pkcs1EncodedBytes);
@@ -197,78 +100,100 @@ public class CryptoCipher {
   private static final int SEQUENCE_TAG = 0x30;
   private static final int BIT_STRING_TAG = 0x03;
   private static final byte[] NO_UNUSED_BITS = new byte[] { 0x00 };
-  private static final byte[] RSA_ALGORITHM_IDENTIFIER_SEQUENCE =
-    {(byte) 0x30, (byte) 0x0d,
-            (byte) 0x06, (byte) 0x09, (byte) 0x2a, (byte) 0x86, (byte) 0x48, (byte) 0x86, (byte) 0xf7, (byte) 0x0d, (byte) 0x01, (byte) 0x01, (byte) 0x01,
-            (byte) 0x05, (byte) 0x00};
+  private static final byte[] RSA_ALGORITHM_IDENTIFIER_SEQUENCE = {
+    (byte) 0x30,
+    (byte) 0x0d,
+    (byte) 0x06,
+    (byte) 0x09,
+    (byte) 0x2a,
+    (byte) 0x86,
+    (byte) 0x48,
+    (byte) 0x86,
+    (byte) 0xf7,
+    (byte) 0x0d,
+    (byte) 0x01,
+    (byte) 0x01,
+    (byte) 0x01,
+    (byte) 0x05,
+    (byte) 0x00,
+  };
 
   private static PublicKey readPkcs1PublicKey(byte[] pkcs1Bytes)
     throws NoSuchAlgorithmException, InvalidKeySpecException, GeneralSecurityException {
     // convert the pkcs1 public key to an x509 favorable format
-    byte[] keyBitString = createDEREncoding(BIT_STRING_TAG, joinPublic(NO_UNUSED_BITS, pkcs1Bytes));
-    byte[] keyInfoValue = joinPublic(RSA_ALGORITHM_IDENTIFIER_SEQUENCE, keyBitString);
+    byte[] keyBitString = createDEREncoding(
+      BIT_STRING_TAG,
+      joinPublic(NO_UNUSED_BITS, pkcs1Bytes)
+    );
+    byte[] keyInfoValue = joinPublic(
+      RSA_ALGORITHM_IDENTIFIER_SEQUENCE,
+      keyBitString
+    );
     byte[] keyInfoSequence = createDEREncoding(SEQUENCE_TAG, keyInfoValue);
     return readX509PublicKey(keyInfoSequence);
   }
 
-  private static byte[] joinPublic(byte[] ... bas)
-  {
-      int len = 0;
-      for (int i = 0; i < bas.length; i++)
-      {
-          len += bas[i].length;
-      }
+  private static byte[] joinPublic(byte[]... bas) {
+    int len = 0;
+    for (int i = 0; i < bas.length; i++) {
+      len += bas[i].length;
+    }
 
-      byte[] buf = new byte[len];
-      int off = 0;
-      for (int i = 0; i < bas.length; i++)
-      {
-          System.arraycopy(bas[i], 0, buf, off, bas[i].length);
-          off += bas[i].length;
-      }
+    byte[] buf = new byte[len];
+    int off = 0;
+    for (int i = 0; i < bas.length; i++) {
+      System.arraycopy(bas[i], 0, buf, off, bas[i].length);
+      off += bas[i].length;
+    }
 
-      return buf;
+    return buf;
   }
 
-  private static byte[] createDEREncoding(int tag, byte[] value)
-  {
-      if (tag < 0 || tag >= 0xFF)
-      {
-          throw new IllegalArgumentException("Currently only single byte tags supported");
-      }
+  private static byte[] createDEREncoding(int tag, byte[] value) {
+    if (tag < 0 || tag >= 0xFF) {
+      throw new IllegalArgumentException(
+        "Currently only single byte tags supported"
+      );
+    }
 
-      byte[] lengthEncoding = createDERLengthEncoding(value.length);
+    byte[] lengthEncoding = createDERLengthEncoding(value.length);
 
-      int size = 1 + lengthEncoding.length + value.length;
-      byte[] derEncodingBuf = new byte[size];
+    int size = 1 + lengthEncoding.length + value.length;
+    byte[] derEncodingBuf = new byte[size];
 
-      int off = 0;
-      derEncodingBuf[off++] = (byte) tag;
-      System.arraycopy(lengthEncoding, 0, derEncodingBuf, off, lengthEncoding.length);
-      off += lengthEncoding.length;
-      System.arraycopy(value, 0, derEncodingBuf, off, value.length);
+    int off = 0;
+    derEncodingBuf[off++] = (byte) tag;
+    System.arraycopy(
+      lengthEncoding,
+      0,
+      derEncodingBuf,
+      off,
+      lengthEncoding.length
+    );
+    off += lengthEncoding.length;
+    System.arraycopy(value, 0, derEncodingBuf, off, value.length);
 
-      return derEncodingBuf;
-  }   
+    return derEncodingBuf;
+  }
 
-  private static byte[] createDERLengthEncoding(int size)
-  {
-      if (size <= 0x7F)
-      {
-          // single byte length encoding
-          return new byte[] { (byte) size };
-      }
-      else if (size <= 0xFF)
-      {
-          // double byte length encoding
-          return new byte[] { (byte) 0x81, (byte) size };
-      }
-      else if (size <= 0xFFFF)
-      {
-          // triple byte length encoding
-          return new byte[] { (byte) 0x82, (byte) (size >> Byte.SIZE), (byte) size };
-      }
+  private static byte[] createDERLengthEncoding(int size) {
+    if (size <= 0x7F) {
+      // single byte length encoding
+      return new byte[] { (byte) size };
+    } else if (size <= 0xFF) {
+      // double byte length encoding
+      return new byte[] { (byte) 0x81, (byte) size };
+    } else if (size <= 0xFFFF) {
+      // triple byte length encoding
+      return new byte[] {
+        (byte) 0x82,
+        (byte) (size >> Byte.SIZE),
+        (byte) size,
+      };
+    }
 
-      throw new IllegalArgumentException("size too large, only up to 64KiB length encoding supported: " + size);
+    throw new IllegalArgumentException(
+      "size too large, only up to 64KiB length encoding supported: " + size
+    );
   }
 }

--- a/api.md
+++ b/api.md
@@ -24,7 +24,7 @@ CapacitorUpdater can be configured with this options:
 | **`resetWhenUpdate`**    | <code>boolean</code> | Automatically delete previous downloaded bundles when a newer native app bundle is installed to the device. Only available for Android and iOS.                                                 | <code>true</code>                              |         |
 | **`updateUrl`**          | <code>string</code>  | Configure the URL / endpoint to which update checks are sent. Only available for Android and iOS.                                                                                               | <code>https://api.capgo.app/auto_update</code> |         |
 | **`statsUrl`**           | <code>string</code>  | Configure the URL / endpoint to which update statistics are sent. Only available for Android and iOS. Set to "" to disable stats reporting.                                                     | <code>https://api.capgo.app/stats</code>       |         |
-| **`privateKey`**         | <code>string</code>  | Configure the private key for end to end live update encryption. Only available for Android and iOS.                                                                                            | <code>undefined</code>                         |         |
+| **`publicKey`**          | <code>string</code>  | Configure the public key for end to end live update encryption. Only available for Android and iOS.                                                                                            | <code>undefined</code>                         |         |
 | **`version`**            | <code>string</code>  | Configure the current version of the app. This will be used for the first update request. If not set, the plugin will get the version from the native code. Only available for Android and iOS. | <code>undefined</code>                         | 4.17.48 |
 | **`directUpdate`**       | <code>boolean</code> | Make the plugin direct install the update when the app what just updated/installed. Only for autoUpdate mode. Only available for Android and iOS.                                               | <code>undefined</code>                         | 5.1.0   |
 | **`periodCheckDelay`**   | <code>number</code>  | Configure the delay period for period update check. the unit is in seconds. Only available for Android and iOS. Cannot be less than 600 seconds (10 minutes).                                   | <code>600 // (10 minutes)</code>               |         |
@@ -52,7 +52,7 @@ In `capacitor.config.json`:
       "resetWhenUpdate": false,
       "updateUrl": https://example.com/api/auto_update,
       "statsUrl": https://example.com/api/stats,
-      "privateKey": undefined,
+      "publicKey": undefined,
       "version": undefined,
       "directUpdate": undefined,
       "periodCheckDelay": undefined,
@@ -86,7 +86,7 @@ const config: CapacitorConfig = {
       resetWhenUpdate: false,
       updateUrl: https://example.com/api/auto_update,
       statsUrl: https://example.com/api/stats,
-      privateKey: undefined,
+      publicKey: undefined,
       version: undefined,
       directUpdate: undefined,
       periodCheckDelay: undefined,

--- a/ios/Plugin/CapacitorUpdater.swift
+++ b/ios/Plugin/CapacitorUpdater.swift
@@ -168,6 +168,7 @@ enum CustomError: Error {
     case cannotUnflat
     case cannotCreateDirectory
     case cannotDeleteDirectory
+    case cannotDecryptSessionKey
 
     // Throw in all other cases
     case unexpected(code: Int)
@@ -204,12 +205,17 @@ extension CustomError: LocalizedError {
         case .cannotDecode:
             return NSLocalizedString(
                 "Decoding the zip failed with this key",
-                comment: "Invalid private key"
+                comment: "Invalid public key"
             )
         case .cannotWrite:
             return NSLocalizedString(
                 "Cannot write to the destination",
                 comment: "Invalid destination"
+            )
+        case .cannotDecryptSessionKey:
+            return NSLocalizedString(
+                "Decrypting the session key failed",
+                comment: "Invalid session key"
             )
         }
     }
@@ -239,7 +245,8 @@ extension CustomError: LocalizedError {
     public var defaultChannel: String = ""
     public var appId: String = ""
     public var deviceID = UIDevice.current.identifierForVendor?.uuidString ?? ""
-    public var privateKey: String = ""
+    public var publicKey: String? = ""
+    public var hasOldPrivateKeyPropertyInConfig: Bool = false
 
     public var notifyDownload: (String, Int) -> Void = { _, _  in }
 
@@ -365,13 +372,14 @@ extension CustomError: LocalizedError {
     }
 
     private func decryptFile(filePath: URL, sessionKey: String, version: String) throws {
-        if self.privateKey.isEmpty || sessionKey.isEmpty  || sessionKey.components(separatedBy: ":").count != 2 {
-            print("\(self.TAG) Cannot found privateKey or sessionKey")
+        if self.publicKey != nil && self.publicKey!.isEmpty || sessionKey.isEmpty  || sessionKey.components(separatedBy: ":").count != 2 {
+            print("\(self.TAG) Cannot find public key or sessionKey")
             return
         }
+
         do {
-            guard let rsaPrivateKey: RSAPrivateKey = .load(rsaPrivateKey: self.privateKey) else {
-                print("cannot decode privateKey", self.privateKey)
+            guard let rsaPublicKey: RSAPublicKey = .load(rsaPublicKey: self.publicKey!) else {
+                print("cannot decode publicKey", self.publicKey!)
                 throw CustomError.cannotDecode
             }
 
@@ -381,21 +389,25 @@ extension CustomError: LocalizedError {
                 throw CustomError.cannotDecode
             }
 
+            //            guard let base64EncodedData = sessionKeyArray[1].data(using: .utf8)! else {
+            //                throw NSError(domain: "Invalid session key data", code: 1, userInfo: nil)
+            //            }
+
             guard let sessionKeyDataEncrypted = Data(base64Encoded: sessionKeyArray[1]) else {
                 throw NSError(domain: "Invalid session key data", code: 1, userInfo: nil)
             }
 
-            guard let sessionKeyDataDecrypted = try? rsaPrivateKey.decrypt(data: sessionKeyDataEncrypted) else {
+            guard let sessionKeyDataDecrypted = try? rsaPublicKey.decrypt(data: sessionKeyDataEncrypted) else {
                 throw NSError(domain: "Failed to decrypt session key data", code: 2, userInfo: nil)
             }
 
-            let aesPrivateKey = AES128Key(iv: ivData, aes128Key: sessionKeyDataDecrypted)
+            let aesPublicKey = AES128Key(iv: ivData, aes128Key: sessionKeyDataDecrypted)
 
             guard let encryptedData = try? Data(contentsOf: filePath) else {
                 throw NSError(domain: "Failed to read encrypted data", code: 3, userInfo: nil)
             }
 
-            guard let decryptedData = try? aesPrivateKey.decrypt(data: encryptedData) else {
+            guard let decryptedData = try? aesPublicKey.decrypt(data: encryptedData) else {
                 throw NSError(domain: "Failed to decrypt data", code: 4, userInfo: nil)
             }
 
@@ -513,7 +525,12 @@ extension CustomError: LocalizedError {
                 case .success:
                     self.notifyDownload(id, 71)
                     do {
+                        if self.hasOldPrivateKeyPropertyInConfig {
+                            print("\(self.TAG) There is still an privateKey property in the config")
+                        }
+
                         try self.decryptFile(filePath: fileURL, sessionKey: sessionKey, version: version)
+
                         checksum = self.getChecksum(filePath: fileURL)
                         try self.saveDownloaded(sourceZip: fileURL, id: id, base: self.documentsDir.appendingPathComponent(self.bundleDirectoryHot))
                         self.notifyDownload(id, 85)

--- a/ios/Plugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Plugin/CapacitorUpdaterPlugin.swift
@@ -22,7 +22,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin {
     let DELAY_CONDITION_PREFERENCES = ""
     private var updateUrl = ""
     private var statsUrl = ""
-    private var defaultPrivateKey = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpQIBAAKCAQEA4pW9olT0FBXXivRCzd3xcImlWZrqkwcF2xTkX/FwXmj9eh9H\nkBLrsQmfsC+PJisRXIOGq6a0z3bsGq6jBpp3/Jr9jiaW5VuPGaKeMaZZBRvi/N5f\nIMG3hZXSOcy0IYg+E1Q7RkYO1xq5GLHseqG+PXvJsNe4R8R/Bmd/ngq0xh/cvcrH\nHpXwO0Aj9tfprlb+rHaVV79EkVRWYPidOLnK1n0EFHFJ1d/MyDIp10TEGm2xHpf/\nBrlb1an8wXEuzoC0DgYaczgTjovwR+ewSGhSHJliQdM0Qa3o1iN87DldWtydImMs\nPjJ3DUwpsjAMRe5X8Et4+udFW2ciYnQo9H0CkwIDAQABAoIBAQCtjlMV/4qBxAU4\nu0ZcWA9yywwraX0aJ3v1xrfzQYV322Wk4Ea5dbSxA5UcqCE29DA1M824t1Wxv/6z\npWbcTP9xLuresnJMtmgTE7umfiubvTONy2sENT20hgDkIwcq1CfwOEm61zjQzPhQ\nkSB5AmEsyR/BZEsUNc+ygR6AWOUFB7tj4yMc32LOTWSbE/znnF2BkmlmnQykomG1\n2oVqM3lUFP7+m8ux1O7scO6IMts+Z/eFXjWfxpbebUSvSIR83GXPQZ34S/c0ehOg\nyHdmCSOel1r3VvInMe+30j54Jr+Ml/7Ee6axiwyE2e/bd85MsK9sVdp0OtelXaqA\nOZZqWvN5AoGBAP2Hn3lSq+a8GsDH726mHJw60xM0LPbVJTYbXsmQkg1tl3NKJTMM\nQqz41+5uys+phEgLHI9gVJ0r+HaGHXnJ4zewlFjsudstb/0nfctUvTqnhEhfNo9I\ny4kufVKPRF3sMEeo7CDVJs4GNBLycEyIBy6Mbv0VcO7VaZqggRwu4no9AoGBAOTK\n6NWYs1BWlkua2wmxexGOzehNGedInp0wGr2l4FDayWjkZLqvB+nNXUQ63NdHlSs4\nWB2Z1kQXZxVaI2tPYexGUKXEo2uFob63uflbuE029ovDXIIPFTPtGNdNXwhHT5a+\nPhmy3sMc+s2BSNM5qaNmfxQxhdd6gRU6oikE+c0PAoGAMn3cKNFqIt27hkFLUgIL\nGKIuf1iYy9/PNWNmEUaVj88PpopRtkTu0nwMpROzmH/uNFriKTvKHjMvnItBO4wV\nkHW+VadvrFL0Rrqituf9d7z8/1zXBNo+juePVe3qc7oiM2NVA4Tv4YAixtM5wkQl\nCgQ15nlqsGYYTg9BJ1e/CxECgYEAjEYPzO2reuUrjr0p8F59ev1YJ0YmTJRMk0ks\nC/yIdGo/tGzbiU3JB0LfHPcN8Xu07GPGOpfYM7U5gXDbaG6qNgfCaHAQVdr/mQPi\nJQ1kCQtay8QCkscWk9iZM1//lP7LwDtxraXqSCwbZSYP9VlUNZeg8EuQqNU2EUL6\nqzWexmcCgYEA0prUGNBacraTYEknB1CsbP36UPWsqFWOvevlz+uEC5JPxPuW5ZHh\nSQN7xl6+PHyjPBM7ttwPKyhgLOVTb3K7ex/PXnudojMUK5fh7vYfChVTSlx2p6r0\nDi58PdD+node08cJH+ie0Yphp7m+D4+R9XD0v0nEvnu4BtAW6DrJasw=\n-----END RSA PRIVATE KEY-----\n"
+    private var defaultPublicKey = "-----BEGIN RSA PUBLIC KEY-----\nMIIBCgKCAQEA4pW9olT0FBXXivRCzd3xcImlWZrqkwcF2xTkX/FwXmj9eh9HkBLr\nsQmfsC+PJisRXIOGq6a0z3bsGq6jBpp3/Jr9jiaW5VuPGaKeMaZZBRvi/N5fIMG3\nhZXSOcy0IYg+E1Q7RkYO1xq5GLHseqG+PXvJsNe4R8R/Bmd/ngq0xh/cvcrHHpXw\nO0Aj9tfprlb+rHaVV79EkVRWYPidOLnK1n0EFHFJ1d/MyDIp10TEGm2xHpf/Brlb\n1an8wXEuzoC0DgYaczgTjovwR+ewSGhSHJliQdM0Qa3o1iN87DldWtydImMsPjJ3\nDUwpsjAMRe5X8Et4+udFW2ciYnQo9H0CkwIDAQAB\n-----END RSA PUBLIC KEY-----\n"
     private var backgroundTaskID: UIBackgroundTaskIdentifier = UIBackgroundTaskIdentifier.invalid
     private var currentVersionNative: Version = "0.0.0"
     private var autoUpdate = false
@@ -67,7 +67,11 @@ public class CapacitorUpdaterPlugin: CAPPlugin {
             periodCheckDelay = periodCheckDelayValue
         }
 
-        implementation.privateKey = getConfig().getString("privateKey", self.defaultPrivateKey)!
+        implementation.publicKey = getConfig().getString("publicKey", self.defaultPublicKey)!
+        implementation.hasOldPrivateKeyPropertyInConfig = false
+        if getConfig().getString("privateKey") != nil && !getConfig().getString("privateKey")!.isEmpty {
+            implementation.hasOldPrivateKeyPropertyInConfig = true
+        }
         implementation.notifyDownload = notifyDownload
         implementation.PLUGIN_VERSION = self.PLUGIN_VERSION
         let config = (self.bridge?.viewController as? CAPBridgeViewController)?.instanceDescriptor().legacyConfig

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -91,13 +91,13 @@ declare module "@capacitor/cli" {
        */
       statsUrl?: string;
       /**
-       * Configure the private key for end to end live update encryption.
+       * Configure the public key for end to end live update encryption.
        *
        * Only available for Android and iOS.
        *
        * @default undefined
        */
-      privateKey?: string;
+      publicKey?: string;
 
       /**
        * Configure the current version of the app. This will be used for the first update request.


### PR DESCRIPTION
This switch allows us to prevent bad actors bypassing E2E encryption with MIM attack.
By using the public key to decrypt the encrypted bundle in the mobile app.