### PR TITLE
Fix sourcemap loading issues

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
Using tooling like webpack and typescript throws errors for missing sourcemaps. Adding this option to the tsconfig should resolve this issue.