### PR TITLE
Refactoring the download stats sending logic for iOS and Android

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
@@ -258,19 +258,12 @@ public class CapacitorUpdater {
       IntentFilter filter = new IntentFilter();
       filter.addAction(DownloadService.NOTIFICATION);
       filter.addAction(DownloadService.PERCENTDOWNLOAD);
-      this.activity.registerReceiver(
-          receiver,
-          filter,
-          RECEIVER_NOT_EXPORTED
-        );
+      this.activity.registerReceiver(receiver, filter, RECEIVER_NOT_EXPORTED);
     } else {
       IntentFilter filter = new IntentFilter();
       filter.addAction(DownloadService.NOTIFICATION);
       filter.addAction(DownloadService.PERCENTDOWNLOAD);
-      this.activity.registerReceiver(
-          receiver,
-          filter
-        );
+      this.activity.registerReceiver(receiver, filter);
     }
   }
 

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
@@ -255,15 +255,21 @@ public class CapacitorUpdater {
 
   public void onResume() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      IntentFilter filter = new IntentFilter();
+      filter.addAction(DownloadService.NOTIFICATION);
+      filter.addAction(DownloadService.PERCENTDOWNLOAD);
       this.activity.registerReceiver(
           receiver,
-          new IntentFilter(DownloadService.NOTIFICATION),
+          filter,
           RECEIVER_NOT_EXPORTED
         );
     } else {
+      IntentFilter filter = new IntentFilter();
+      filter.addAction(DownloadService.NOTIFICATION);
+      filter.addAction(DownloadService.PERCENTDOWNLOAD);
       this.activity.registerReceiver(
           receiver,
-          new IntentFilter(DownloadService.NOTIFICATION)
+          filter
         );
     }
   }

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -118,7 +118,7 @@ public class DownloadService extends IntentService {
 
         int bytesRead = -1;
         byte[] buffer = new byte[4096];
-        int lastPercent = 0;
+        int lastNotifiedPercent = 0; 
         while ((bytesRead = inputStream.read(buffer)) != -1) {
           outputStream.write(buffer, 0, bytesRead);
           downloadedBytes += bytesRead;
@@ -128,10 +128,11 @@ public class DownloadService extends IntentService {
           }
           // Computing percentage
           int percent = calcTotalPercent(downloadedBytes, contentLength);
-          if (percent != lastPercent) {
-            notifyDownload(id, percent);
-            lastPercent = percent;
-          }
+          while (lastNotifiedPercent + 10 <= percent) {
+            lastNotifiedPercent += 10;
+            notifyDownload(id, lastNotifiedPercent);
+        }
+          
         }
 
         outputStream.close();

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -118,7 +118,7 @@ public class DownloadService extends IntentService {
 
         int bytesRead = -1;
         byte[] buffer = new byte[4096];
-        int lastNotifiedPercent = 0; 
+        int lastNotifiedPercent = 0;
         while ((bytesRead = inputStream.read(buffer)) != -1) {
           outputStream.write(buffer, 0, bytesRead);
           downloadedBytes += bytesRead;
@@ -131,8 +131,7 @@ public class DownloadService extends IntentService {
           while (lastNotifiedPercent + 10 <= percent) {
             lastNotifiedPercent += 10;
             notifyDownload(id, lastNotifiedPercent);
-        }
-          
+          }
         }
 
         outputStream.close();

--- a/ios/Plugin/CapacitorUpdater.swift
+++ b/ios/Plugin/CapacitorUpdater.swift
@@ -1104,7 +1104,7 @@ extension CustomError: LocalizedError {
         
         let operation = BlockOperation {
             let semaphore = DispatchSemaphore(value: 0)
-             let request = AF.request(
+            AF.request(
                  self.statsUrl,
                  method: .post,
                  parameters: parameters,

--- a/ios/Plugin/CapacitorUpdater.swift
+++ b/ios/Plugin/CapacitorUpdater.swift
@@ -661,7 +661,7 @@ extension CustomError: LocalizedError {
                      self.savePartialData(startingAt: UInt64(totalReceivedBytes)) // Saving the received data in the package.tmp file
                      totalReceivedBytes += Int64(data.count)
                      
-                     let percent = Int((Double(totalReceivedBytes) / Double(targetSize)) * 100.0)
+                     let percent = Int((Double(totalReceivedBytes) / Double(targetSize)) * 70.0)
                      
                      print("\(self.TAG) Downloading: \(percent)%")
                      let currentMilestone = (percent / 10) * 10
@@ -728,8 +728,9 @@ extension CustomError: LocalizedError {
         
         do {
             checksum = self.calcChecksum(filePath: finalPath)
+            print("\(self.TAG) Downloading: 80% (unzipping)")
             try self.saveDownloaded(sourceZip: finalPath, id: id, base: self.libraryDir.appendingPathComponent(self.bundleDirectory), notify: true)
-            self.notifyDownload(id: id, percent: 90)
+            
         } catch {
             print("\(self.TAG) Failed to unzip file: \(error)")
             self.saveBundleInfo(id: id, bundle: BundleInfo(id: id, version: version, status: BundleStatus.ERROR, downloaded: Date(), checksum: checksum))
@@ -738,10 +739,13 @@ extension CustomError: LocalizedError {
             throw error
         }
         
+        self.notifyDownload(id: id, percent: 90)
+        print("\(self.TAG) Downloading: 90% (wrapping up)")
         let info = BundleInfo(id: id, version: version, status: BundleStatus.PENDING, downloaded: Date(), checksum: checksum)
         self.saveBundleInfo(id: id, bundle: info)
-        self.notifyDownload(id: id, percent: 100)
         self.cleanDlData()
+        self.notifyDownload(id: id, percent: 100)
+        print("\(self.TAG) Downloading: 100% (complete)")
         return info
     }
     private func ensureResumableFilesExist() {


### PR DESCRIPTION
As adressed in #435, changes were needed for how the download stats were sent.

This PR ensures that the download progress and related statistics (download_x) are transmitted in the correct sequence for both Android and iOS platforms.

It also fixes the broadcastReceiver on Android to correctly receives broadcast about the download status update.
