### PR TITLE
fix: checksum differs on android and ios

### DIFF
--- a/ios/Plugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Plugin/CapacitorUpdaterPlugin.swift
@@ -289,7 +289,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         DispatchQueue.global(qos: .background).async {
             do {
                 let next = try self.implementation.download(url: url!, version: version, sessionKey: sessionKey)
-                if !self.implementation.hasOldPrivateKeyPropertyInConfig {
+                if !self.implementation.hasOldPrivateKeyPropertyInConfig && !sessionKey.isEmpty {
                     checksum = try self.implementation.decryptChecksum(checksum: checksum, version: version)
                 }
                 if (checksum != "" || self.implementation.publicKey != "") && next.getChecksum() != checksum {


### PR DESCRIPTION
In case of manual update, the decrypted checksum is different from the one generated by `npx @capgo/cli bundle zip --path www`