### PR TITLE
fix: add null check

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -263,7 +263,7 @@ public class DownloadService extends Worker {
                 if (infoFile.exists() && tempFile.exists()) {
                     try (BufferedReader reader = new BufferedReader(new FileReader(infoFile))) {
                         String updateVersion = reader.readLine();
-                        if (!updateVersion.equals(version)) {
+                        if (updateVersion != null && !updateVersion.equals(version)) {
                             clearDownloadData(documentsDir);
                         } else {
                             downloadedBytes = tempFile.length();


### PR DESCRIPTION
If the first download fails in a way that results in the infoFile being created but no version being written into it. The DownloadService is in a broken state that always results in a Null-Pointer after trying to compare the version in that file.

A simple null check should fix this.

This may also be the cause for #547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the update download process by adding a safeguard check to prevent interruptions when version information is missing, resulting in improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->