### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ This informs Capacitor Updater that the current update bundle has loaded succesf
 - Add this to your application.
 ```javascript
   const version = await CapacitorUpdater.download({
+    version: '0.0.4',
     url: 'https://github.com/Cap-go/demo-app/releases/download/0.0.4/dist.zip',
   })
   await CapacitorUpdater.set(version); // sets the new version, and reloads the app
@@ -138,6 +139,7 @@ You might also consider performing auto-update when application state changes, a
       if (state.isActive) {
         // Ensure download occurs while the app is active, or download may fail
         version = await CapacitorUpdater.download({
+          version: '0.0.4',
           url: 'https://github.com/Cap-go/demo-app/releases/download/0.0.4/dist.zip',
         })
       }


### PR DESCRIPTION
Add version parameter for CapacitorUpdater.download in README.md because it's needed for the DownloadOptions interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README examples to include the version property when using the download method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->