### PR TITLE
fix: Prevent fallthrough in android checkCancelDelay

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/DelayUpdateUtils.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DelayUpdateUtils.java
@@ -89,8 +89,8 @@ public class DelayUpdateUtils {
                             source.toString() +
                             ")"
                         );
-                        break;
                     }
+                    break;
                 case DelayUntilNext.kill:
                     if (source == CancelDelaySource.KILLED) {
                         this.installNext.run();


### PR DESCRIPTION
Fixes an issue where the `switch` branch for `DelayUntilNext.background` would fall through to the `DelayUntilNext.kill` branch when the source was `CancelDelaySource.FOREGROUND`. This caused the `else` in the `kill` branch to execute, which immediately restores the delay condition that was removed.