### PR TITLE
feat: wrap android lifecycle methods with try-catch

### DIFF
--- a/android/.project
+++ b/android/.project
@@ -6,22 +6,28 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1635097622717</id>
+			<id>1751524353387</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -302,16 +302,19 @@ public class CapacitorUpdaterPlugin extends Plugin {
     private void hideSplashscreen() {
         try {
             // Use JavaScript evaluation to hide the splashscreen - simpler and more reliable
-            getBridge().getWebView().post(() -> {
-                getBridge().eval(
-                    "(function() { " +
-                    "  if (window.Capacitor && window.Capacitor.Plugins && window.Capacitor.Plugins.SplashScreen) { " +
-                    "    window.Capacitor.Plugins.SplashScreen.hide(); " +
-                    "  } " +
-                    "})()",
-                    null
-                );
-            });
+            getBridge()
+                .getWebView()
+                .post(() -> {
+                    getBridge()
+                        .eval(
+                            "(function() { " +
+                            "  if (window.Capacitor && window.Capacitor.Plugins && window.Capacitor.Plugins.SplashScreen) { " +
+                            "    window.Capacitor.Plugins.SplashScreen.hide(); " +
+                            "  } " +
+                            "})()",
+                            null
+                        );
+                });
             logger.info("Splashscreen hidden automatically via JavaScript");
         } catch (Exception e) {
             logger.error("Error hiding splashscreen: " + e.getMessage());
@@ -1455,62 +1458,82 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
     @Override
     public void handleOnStart() {
-        if (isPreviousMainActivity) {
-            this.appMovedToForeground();
-        }
-        logger.info("onActivityStarted " + getActivity().getClass().getName());
-        isPreviousMainActivity = true;
-
-        // Initialize shake menu if enabled and activity is BridgeActivity
-        if (shakeMenuEnabled && getActivity() instanceof com.getcapacitor.BridgeActivity && shakeMenu == null) {
-            try {
-                shakeMenu = new ShakeMenu(this, (com.getcapacitor.BridgeActivity) getActivity(), logger);
-                logger.info("Shake menu initialized");
-            } catch (Exception e) {
-                logger.error("Failed to initialize shake menu: " + e.getMessage());
+        try {
+            if (isPreviousMainActivity) {
+                this.appMovedToForeground();
             }
+            logger.info("onActivityStarted " + getActivity().getClass().getName());
+            isPreviousMainActivity = true;
+
+            // Initialize shake menu if enabled and activity is BridgeActivity
+            if (shakeMenuEnabled && getActivity() instanceof com.getcapacitor.BridgeActivity && shakeMenu == null) {
+                try {
+                    shakeMenu = new ShakeMenu(this, (com.getcapacitor.BridgeActivity) getActivity(), logger);
+                    logger.info("Shake menu initialized");
+                } catch (Exception e) {
+                    logger.error("Failed to initialize shake menu: " + e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Failed to run handleOnStart: " + e.getMessage());
         }
     }
 
     @Override
     public void handleOnStop() {
-        isPreviousMainActivity = isMainActivity();
-        if (isPreviousMainActivity) {
-            this.appMovedToBackground();
+        try {
+            isPreviousMainActivity = isMainActivity();
+            if (isPreviousMainActivity) {
+                this.appMovedToBackground();
+            }
+        } catch (Exception e) {
+            logger.error("Failed to run handleOnStop: " + e.getMessage());
         }
     }
 
     @Override
     public void handleOnResume() {
-        if (backgroundTask != null && taskRunning) {
-            backgroundTask.interrupt();
+        try {
+            if (backgroundTask != null && taskRunning) {
+                backgroundTask.interrupt();
+            }
+            this.implementation.activity = getActivity();
+        } catch (Exception e) {
+            logger.error("Failed to run handleOnResume: " + e.getMessage());
         }
-        this.implementation.activity = getActivity();
     }
 
     @Override
     public void handleOnPause() {
-        this.implementation.activity = getActivity();
+        try {
+            this.implementation.activity = getActivity();
+        } catch (Exception e) {
+            logger.error("Failed to run handleOnPause: " + e.getMessage());
+        }
     }
 
     @Override
     public void handleOnDestroy() {
-        logger.info("onActivityDestroyed " + getActivity().getClass().getName());
-        this.implementation.activity = getActivity();
-        counterActivityCreate--;
-        if (counterActivityCreate == 0) {
-            this.appKilled();
-        }
-
-        // Clean up shake menu
-        if (shakeMenu != null) {
-            try {
-                shakeMenu.stop();
-                shakeMenu = null;
-                logger.info("Shake menu cleaned up");
-            } catch (Exception e) {
-                logger.error("Failed to clean up shake menu: " + e.getMessage());
+        try {
+            logger.info("onActivityDestroyed " + getActivity().getClass().getName());
+            this.implementation.activity = getActivity();
+            counterActivityCreate--;
+            if (counterActivityCreate == 0) {
+                this.appKilled();
             }
+
+            // Clean up shake menu
+            if (shakeMenu != null) {
+                try {
+                    shakeMenu.stop();
+                    shakeMenu = null;
+                    logger.info("Shake menu cleaned up");
+                } catch (Exception e) {
+                    logger.error("Failed to clean up shake menu: " + e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Failed to run handleOnDestroy: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
To prevent another accidental outage ( https://github.com/Cap-go/capacitor-updater/issues/587 ), i wrapped all android lifecycle methods with a try-catch. This does not prevent the error as that is a proguard setup, but it prevents the app from going down by anything plugin related.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and stability by adding comprehensive exception logging to app lifecycle events.

* **Chores**
  * Updated Android project configuration for enhanced compatibility with development tools.
  * Refined resource filtering to improve project setup accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->