### PR TITLE
fix: ensure deletion of leftover bundle files

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
@@ -339,6 +339,9 @@ public class CapacitorUpdater {
             }
             // Remove the decryption for manifest downloads
         } catch (Exception e) {
+            if (downloaded != null && downloaded.exists()) {
+              downloaded.delete();
+            }
             final Boolean res = this.delete(id);
             if (!res) {
                 Log.i(CapacitorUpdater.TAG, "Double error, cannot cleanup: " + version);
@@ -362,8 +365,8 @@ public class CapacitorUpdater {
                 this.notifyDownload(id, 91);
                 final String idName = bundleDirectory + "/" + id;
                 this.flattenAssets(downloaded, idName);
-                downloaded.delete();
             }
+            downloaded.delete();
             this.notifyDownload(id, 100);
             this.saveBundleInfo(id, null);
             BundleInfo next = new BundleInfo(id, version, BundleStatus.PENDING, new Date(System.currentTimeMillis()), checksum);


### PR DESCRIPTION
@riderx Thank you for taking the time to respond to the issue I opened.

This PR fixes [the bug in this issue](https://github.com/Cap-go/capacitor-updater/issues/613) for v6 and ensures leftover files are removed properly.

I am targeting the v6 branch because our project is still on Capacitor v6 and cannot migrate to v7 immediately due to the size of existing codebases. This backport will ensure that v6 users can benefit from the fix while preparing for an eventual upgrade to v7.
I have tested this fix in our codebase on Capacitor v6, and it resolved the issue as expected.

We would greatly appreciate it if this PR could be considered for inclusion, and if a new v6 release could be published so that the community can make use of the fix.

