### PR TITLE
fix(ios): retry incomplete downloads so updates apply instead of hanging

### DIFF
--- a/ios/Sources/CapacitorUpdaterPlugin/BundleInfo.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/BundleInfo.swift
@@ -69,6 +69,10 @@ import Foundation
         return BundleStatus.DELETING == self.status
     }
 
+    public func isDownloading() -> Bool {
+        return BundleStatus.DOWNLOADING == self.status
+    }
+
     public func isDownloaded() -> Bool {
         return !self.isBuiltin() && self.downloaded != "" &&
             self.downloaded != BundleInfo.DOWNLOADED_BUILTIN && !self.isDeleted() && !self.isDeleting()

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -1809,6 +1809,14 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
+    private func queueBundleForNextBackgroundInstall(_ next: BundleInfo) -> Bool {
+        guard self.implementation.setNextBundle(next: next.getId()) else {
+            self.logger.error("Failed to queue downloaded bundle as next: \(next.toString())")
+            return false
+        }
+        return true
+    }
+
     private func applyDownloadedBundleForDirectUpdate(_ next: BundleInfo) -> Bool {
         let previousState = self.implementation.captureResetState()
         let previousBundleName = self.implementation.getCurrentBundle().getVersionName()
@@ -3993,6 +4001,13 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         isAutoUpdateModeEnabled(autoUpdateMode) && autoUpdateMode != autoUpdateModeOnlyDownload
     }
 
+    /// Incomplete leftovers must be downloaded again. Android already skips
+    /// `DOWNLOADING` here; iOS used to treat them as ready, then `setNextBundle`
+    /// failed quietly and the update never applied.
+    static func shouldRetryDownloadForExistingBundle(_ bundle: BundleInfo) -> Bool {
+        bundle.isDeleted() || bundle.isDeleting() || bundle.isDownloading()
+    }
+
     static func isDirectUpdateMode(_ directUpdateMode: String) -> Bool {
         directUpdateMode == autoUpdateModeInstall || directUpdateMode == autoUpdateModeLaunch || directUpdateMode == autoUpdateModeAlways
     }
@@ -4361,14 +4376,16 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                 do {
                     self.logger.info("New bundle: \(latestVersionName) found. Current is: \(current.getVersionName()). \(messageUpdate)")
                     var nextImpl = self.implementation.getBundleInfoByVersionName(version: latestVersionName)
-                    if nextImpl == nil || nextImpl?.isDeleted() == true {
-                        if nextImpl?.isDeleted() == true {
-                            self.logger.info("Latest bundle already exists and will be deleted, download will overwrite it.")
-                            let res = self.implementation.delete(id: nextImpl!.getId(), removeInfo: true)
-                            if res {
-                                self.logger.info("Failed bundle deleted: \(nextImpl!.toString())")
+                    let needsDownload = nextImpl.map(Self.shouldRetryDownloadForExistingBundle) ?? true
+                    if needsDownload {
+                        if let existing = nextImpl {
+                            self.logger.info("Latest bundle already exists in incomplete state (\(existing.getStatus())) and will be deleted, download will overwrite it.")
+                            _ = self.implementation.setNextBundle(next: Optional<String>.none)
+                            let deleted = self.implementation.delete(id: existing.getId(), removeInfo: true)
+                            if deleted {
+                                self.logger.info("Incomplete bundle deleted: \(existing.toString())")
                             } else {
-                                self.logger.error("Failed to delete failed bundle: \(nextImpl!.toString())")
+                                self.logger.error("Failed to delete incomplete bundle: \(existing.toString())")
                             }
                         }
                         self.consumeOnLaunchDirectUpdateAttempt(plannedDirectUpdate: plannedDirectUpdate)
@@ -4455,8 +4472,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                                 error: false,
                                 plannedDirectUpdate: plannedDirectUpdate
                             )
-                        } else {
-                            _ = self.implementation.setNextBundle(next: next.getId())
+                        } else if self.queueBundleForNextBackgroundInstall(next) {
                             self.notifyListeners("updateAvailable", data: ["bundle": next.toJSON()])
                             self.endBackGroundTaskWithNotif(
                                 msg: "Direct update reload failed, update will install next background",
@@ -4465,20 +4481,35 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                                 error: false,
                                 plannedDirectUpdate: plannedDirectUpdate
                             )
+                        } else {
+                            self.endBackGroundTaskWithNotif(
+                                msg: "Direct update reload failed, and next bundle could not be queued",
+                                latestVersionName: latestVersionName,
+                                current: current,
+                                plannedDirectUpdate: plannedDirectUpdate
+                            )
                         }
                     } else if self.shouldAutoSetNextBundle() {
                         if plannedDirectUpdate && !directUpdateAllowed {
                             self.logger.info("Direct update skipped because splashscreen timeout occurred. Update will install on next app background.")
                         }
-                        self.notifyListeners("updateAvailable", data: ["bundle": next.toJSON()])
-                        _ = self.implementation.setNextBundle(next: next.getId())
-                        self.endBackGroundTaskWithNotif(
-                            msg: "update downloaded, will install next background",
-                            latestVersionName: latestVersionName,
-                            current: current,
-                            error: false,
-                            plannedDirectUpdate: plannedDirectUpdate
-                        )
+                        if self.queueBundleForNextBackgroundInstall(next) {
+                            self.notifyListeners("updateAvailable", data: ["bundle": next.toJSON()])
+                            self.endBackGroundTaskWithNotif(
+                                msg: "update downloaded, will install next background",
+                                latestVersionName: latestVersionName,
+                                current: current,
+                                error: false,
+                                plannedDirectUpdate: plannedDirectUpdate
+                            )
+                        } else {
+                            self.endBackGroundTaskWithNotif(
+                                msg: "Update downloaded, but next bundle could not be queued",
+                                latestVersionName: latestVersionName,
+                                current: current,
+                                plannedDirectUpdate: plannedDirectUpdate
+                            )
+                        }
                     } else {
                         self.logger.info("autoUpdate is set to onlyDownload, downloaded update will not be set as next bundle")
                         self.notifyListeners("updateAvailable", data: ["bundle": next.toJSON()], retainUntilConsumed: true)

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -82,6 +82,7 @@ private final class FreshDownloadCapgoUpdater: CapgoUpdater {
     var lastDeletedId: String?
     var setNextBundleCalls = 0
     var lastSetNextBundleId: String?
+    var setNextBundleSucceeds = true
     var sentStatsActions: [String] = []
 
     override func getLatest(url: URL, channel: String?, appIdOverride: String? = nil) -> AppVersion {
@@ -127,19 +128,11 @@ private final class FreshDownloadCapgoUpdater: CapgoUpdater {
     override func setNextBundle(next: String?) -> Bool {
         setNextBundleCalls += 1
         lastSetNextBundleId = next
-        return true
+        return setNextBundleSucceeds
     }
 
     override func sendStats(action: String, versionName: String? = nil, oldVersionName: String? = "") {
         sentStatsActions.append(action)
-    }
-}
-
-private final class FailSetNextCapgoUpdater: FreshDownloadCapgoUpdater {
-    override func setNextBundle(next: String?) -> Bool {
-        setNextBundleCalls += 1
-        lastSetNextBundleId = next
-        return next == nil
     }
 }
 
@@ -2146,7 +2139,8 @@ class CapacitorUpdaterTests: XCTestCase {
 
     func testFailedSetNextBundleAfterDownloadNotifiesFailure() {
         let downloaded = makeOnlyDownloadBundle()
-        let implementation = FailSetNextCapgoUpdater()
+        let implementation = FreshDownloadCapgoUpdater()
+        implementation.setNextBundleSucceeds = false
         let (testPlugin, _) = makeAtBackgroundPlugin(downloaded: downloaded, implementation: implementation)
 
         testPlugin.backgroundDownload()

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -77,6 +77,9 @@ private final class FreshDownloadCapgoUpdater: CapgoUpdater {
         checksum: "builtin"
     )
     var onDownloadStart: (() -> Void)?
+    var downloadCalls = 0
+    var deleteCalls = 0
+    var lastDeletedId: String?
     var setNextBundleCalls = 0
     var lastSetNextBundleId: String?
     var sentStatsActions: [String] = []
@@ -104,11 +107,21 @@ private final class FreshDownloadCapgoUpdater: CapgoUpdater {
     }
 
     override func download(url: URL, version: String, sessionKey: String, link: String? = nil, comment: String? = nil) throws -> BundleInfo {
+        downloadCalls += 1
         onDownloadStart?()
         if let downloadedBundleValue {
             return downloadedBundleValue
         }
         throw NSError(domain: "CapacitorUpdaterPluginTests", code: 1)
+    }
+
+    override func delete(id: String, removeInfo _: Bool) -> Bool {
+        deleteCalls += 1
+        lastDeletedId = id
+        if existingBundleValue?.getId() == id {
+            existingBundleValue = nil
+        }
+        return true
     }
 
     override func setNextBundle(next: String?) -> Bool {
@@ -119,6 +132,14 @@ private final class FreshDownloadCapgoUpdater: CapgoUpdater {
 
     override func sendStats(action: String, versionName: String? = nil, oldVersionName: String? = "") {
         sentStatsActions.append(action)
+    }
+}
+
+private final class FailSetNextCapgoUpdater: FreshDownloadCapgoUpdater {
+    override func setNextBundle(next: String?) -> Bool {
+        setNextBundleCalls += 1
+        lastSetNextBundleId = next
+        return next == nil
     }
 }
 
@@ -508,6 +529,31 @@ class CapacitorUpdaterTests: XCTestCase {
         return (testPlugin, freshDownloadImplementation)
     }
 
+    private func makeAtBackgroundPlugin(
+        existing: BundleInfo? = nil,
+        downloaded: BundleInfo? = nil,
+        implementation: FreshDownloadCapgoUpdater = FreshDownloadCapgoUpdater()
+    ) -> (TestableCapacitorUpdaterPlugin, FreshDownloadCapgoUpdater) {
+        implementation.currentBundleValue = BundleInfo(
+            id: "test-id",
+            version: "1.0.0",
+            status: .SUCCESS,
+            downloaded: Date(),
+            checksum: "abc123"
+        )
+        implementation.latestResponse = makeOnlyDownloadLatest()
+        implementation.existingBundleValue = existing
+        implementation.downloadedBundleValue = downloaded
+
+        let testPlugin = TestableCapacitorUpdaterPlugin()
+        testPlugin.implementation = implementation
+        testPlugin.setAutoUpdateModeForTesting("atBackground")
+        testPlugin.setUpdateUrlForTesting("https://example.com/channel")
+        CryptoCipher.setLogger(Logger(withTag: "TestLogger"))
+
+        return (testPlugin, implementation)
+    }
+
     private func assertOnlyDownloadLeavesUpdateManual(
         plugin testPlugin: TestableCapacitorUpdaterPlugin,
         implementation freshDownloadImplementation: FreshDownloadCapgoUpdater
@@ -783,6 +829,59 @@ class CapacitorUpdaterTests: XCTestCase {
 
         XCTAssertTrue(bundleInfo.isDeleted())
         XCTAssertFalse(bundleInfo.isErrorStatus())
+        XCTAssertFalse(bundleInfo.isDownloading())
+    }
+
+    func testBundleInfoDownloadingStatus() {
+        let bundleInfo = BundleInfo(
+            id: "stale-id",
+            version: "2.0.0",
+            status: .DOWNLOADING,
+            downloaded: Date(),
+            checksum: ""
+        )
+
+        XCTAssertTrue(bundleInfo.isDownloading())
+        XCTAssertTrue(bundleInfo.isDownloaded())
+        XCTAssertFalse(bundleInfo.isDeleted())
+        XCTAssertFalse(bundleInfo.isDeleting())
+        XCTAssertFalse(bundleInfo.isErrorStatus())
+    }
+
+    func testShouldRetryDownloadForIncompleteExistingBundles() {
+        let pending = BundleInfo(
+            id: "pending-id",
+            version: "2.0.0",
+            status: .PENDING,
+            downloaded: Date(),
+            checksum: "abc123"
+        )
+        let downloading = BundleInfo(
+            id: "downloading-id",
+            version: "2.0.0",
+            status: .DOWNLOADING,
+            downloaded: Date(),
+            checksum: ""
+        )
+        let deleting = BundleInfo(
+            id: "deleting-id",
+            version: "2.0.0",
+            status: .DELETING,
+            downloaded: Date(),
+            checksum: "abc123"
+        )
+        let deleted = BundleInfo(
+            id: "deleted-id",
+            version: "2.0.0",
+            status: .DELETED,
+            downloaded: Date(),
+            checksum: "abc123"
+        )
+
+        XCTAssertFalse(CapacitorUpdaterPlugin.shouldRetryDownloadForExistingBundle(pending))
+        XCTAssertTrue(CapacitorUpdaterPlugin.shouldRetryDownloadForExistingBundle(downloading))
+        XCTAssertTrue(CapacitorUpdaterPlugin.shouldRetryDownloadForExistingBundle(deleting))
+        XCTAssertTrue(CapacitorUpdaterPlugin.shouldRetryDownloadForExistingBundle(deleted))
     }
 
     func testBuildUserAgentStripsNonIsoCharacters() {
@@ -2015,6 +2114,46 @@ class CapacitorUpdaterTests: XCTestCase {
         XCTAssertFalse(testPlugin.notifiedEventNames.contains("updateAvailable"))
         XCTAssertTrue(testPlugin.notifiedEventNames.contains("noNeedUpdate"))
         XCTAssertEqual(freshDownloadImplementation.setNextBundleCalls, 0)
+    }
+
+    func testStaleDownloadingBundleIsRedownloadedInsteadOfQueued() {
+        let stale = makeOnlyDownloadBundle(id: "stale-id", status: .DOWNLOADING, checksum: "")
+        let downloaded = makeOnlyDownloadBundle(id: "fresh-id")
+        let (testPlugin, implementation) = makeAtBackgroundPlugin(existing: stale, downloaded: downloaded)
+
+        testPlugin.backgroundDownload()
+
+        XCTAssertEqual(implementation.downloadCalls, 1)
+        XCTAssertEqual(implementation.deleteCalls, 1)
+        XCTAssertEqual(implementation.lastDeletedId, "stale-id")
+        XCTAssertEqual(implementation.lastSetNextBundleId, "fresh-id")
+        XCTAssertTrue(testPlugin.notifiedEventNames.contains("updateAvailable"))
+        XCTAssertFalse(testPlugin.notifiedEventNames.contains("downloadFailed"))
+    }
+
+    func testPendingExistingBundleIsReusedWithoutRedownload() {
+        let existing = makeOnlyDownloadBundle()
+        let (testPlugin, implementation) = makeAtBackgroundPlugin(existing: existing)
+
+        testPlugin.backgroundDownload()
+
+        XCTAssertEqual(implementation.downloadCalls, 0)
+        XCTAssertEqual(implementation.deleteCalls, 0)
+        XCTAssertEqual(implementation.setNextBundleCalls, 1)
+        XCTAssertEqual(implementation.lastSetNextBundleId, existing.getId())
+        XCTAssertFalse(testPlugin.notifiedEventNames.contains("downloadFailed"))
+    }
+
+    func testFailedSetNextBundleAfterDownloadNotifiesFailure() {
+        let downloaded = makeOnlyDownloadBundle()
+        let implementation = FailSetNextCapgoUpdater()
+        let (testPlugin, _) = makeAtBackgroundPlugin(downloaded: downloaded, implementation: implementation)
+
+        testPlugin.backgroundDownload()
+
+        XCTAssertEqual(implementation.downloadCalls, 1)
+        XCTAssertTrue(testPlugin.notifiedEventNames.contains("downloadFailed"))
+        XCTAssertTrue(implementation.sentStatsActions.contains("download_fail"))
     }
 
     func testNoNewVersionAvailableDoesNotNotifyDownloadFailed() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- iOS now treats leftover `DOWNLOADING` / `DELETING` / `DELETED` bundles as incomplete and downloads them again, instead of treating them as ready to apply.
- If a completed download cannot be queued as the next bundle, the plugin now reports `downloadFailed` instead of going silent.

## Why
Some iOS devices download an update, then never apply it and never fail. The usual path:

1. iOS suspends the app during unzip/manifest (background task is ~30s).
2. Bundle metadata stays `DOWNLOADING` with missing `index.html`.
3. Next launch finds that leftover by version name and skips the download.
4. `setNextBundle` fails because the files are incomplete, and the return value was ignored.

Android already skipped `DOWNLOADING` leftovers. Manifest/delta updates skip the zip checksum check, so this hung more often on recent iOS builds.

Default `autoUpdate: atBackground` still waits for the next background to apply a *complete* download. That is unchanged.

## How
- Reuse an existing bundle only when it is not deleted, deleting, or still downloading.
- Delete the incomplete leftover (after clearing `next`) and download again.
- Fail the update check when `setNextBundle` returns false.

## Testing
- Added iOS unit tests for:
  - `isDownloading` / retry helper
  - stale `DOWNLOADING` leftover is deleted and downloaded again
  - complete `PENDING` bundle is reused
  - `setNextBundle` failure emits `downloadFailed`
- This environment cannot run `xcodebuild`. CI should run `CapacitorUpdaterPluginTests`.

## Not Tested
- Device reproduction: kill the app mid-manifest download, relaunch, confirm the update applies or fails.
- Direct-update / `atInstall` apply timing (unchanged).
- Cases where the user never backgrounds the app after a successful download (`atBackground` by design).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae82c760-b047-4fc8-a17c-6793149d3fcb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae82c760-b047-4fc8-a17c-6793149d3fcb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-updater/pr/874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790849305&installation_model_id=430928&pr_number=874&repository=Cap-go%2Fcapacitor-updater&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-updater%2Fpull%2F874&signature=00fc006d55e3ddbfe5d03be57c9c797cc850f9ed9799dd84050802a215e0963e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-updater/pull/874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS bundle update reliability when downloads are incomplete, stale, or interrupted.
  * Existing incomplete downloads are now replaced and retried instead of being incorrectly reused.
  * Download and background installation failures now report status through completion notifications.
  * Improved handling of bundles queued for installation in the background.
* **Tests**
  * Added coverage for download retries, stale bundle replacement, pending bundle reuse, and failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->