### PR TITLE
ci: auto-backport main onto Capacitor LTS branches

### DIFF
--- a/.github/lts-backport.json
+++ b/.github/lts-backport.json
@@ -1,0 +1,61 @@
+{
+  "$comment": "Instructions for backporting main onto Capacitor LTS branches. After merging main (prefer main on conflicts), restore these pins so each major stays compatible. Add a new major here when main moves forward. npm dist-tags are applied by .github/workflows/build.yml from the tag major.",
+  "targets": {
+    "v5": {
+      "branch": "v5",
+      "major": 5,
+      "npmTag": "lts-v5",
+      "capacitorRange": "^5.0.0",
+      "docgen": "^0.2.1",
+      "iosDeployment": "13.0",
+      "iosPlatform": ".v13",
+      "swiftPm": "5.0.0",
+      "dropUiScene": true,
+      "android": {
+        "minSdk": 23,
+        "compileSdk": 35,
+        "targetSdk": 35,
+        "java": 21,
+        "okhttp": "4.12.0",
+        "agp": "8.7.2"
+      }
+    },
+    "v6": {
+      "branch": "v6",
+      "major": 6,
+      "npmTag": "lts-v6",
+      "capacitorRange": "^6.0.0",
+      "iosDeployment": "13.0",
+      "iosPlatform": ".v13",
+      "swiftPm": "6.0.0",
+      "bigIntExact": "5.2.0",
+      "dropUiScene": true,
+      "android": {
+        "minSdk": 22,
+        "compileSdk": 34,
+        "targetSdk": 34,
+        "java": 17,
+        "okhttp": "4.12.0",
+        "agp": "8.7.2"
+      }
+    },
+    "v7": {
+      "branch": "v7",
+      "major": 7,
+      "npmTag": "lts-v7",
+      "capacitorRange": "^7.0.0",
+      "iosDeployment": "14.0",
+      "iosPlatform": ".v14",
+      "swiftPm": "7.0.0",
+      "dropUiScene": true,
+      "android": {
+        "minSdk": 23,
+        "compileSdk": 35,
+        "targetSdk": 35,
+        "java": 21,
+        "okhttp": "4.12.0",
+        "agp": "8.7.2"
+      }
+    }
+  }
+}

--- a/.github/scripts/backport-lts.sh
+++ b/.github/scripts/backport-lts.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Merge main into a Capacitor LTS branch, restore major-specific pins, then
+# push so bump_version.yml can tag and build.yml can publish.
+
+set -euo pipefail
+
+TARGET="${1:-}"
+if [ -z "$TARGET" ]; then
+  echo "Usage: backport-lts.sh v5|v6|v7"
+  exit 1
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+# Scripts live on main. Copy them before switching onto the LTS branch.
+SCRIPT_STASH="$(mktemp -d)"
+cp -a "$ROOT/.github/scripts/." "$SCRIPT_STASH/"
+cp "$ROOT/.github/lts-backport.json" "$SCRIPT_STASH/lts-backport.json"
+HELPERS="$SCRIPT_STASH/sync-gh-helpers.sh"
+RESTORE="$SCRIPT_STASH/restore-lts-constraints.mjs"
+# shellcheck source=/dev/null
+source "$HELPERS"
+
+if ! jq -e --arg target "$TARGET" '.targets[$target]' "$SCRIPT_STASH/lts-backport.json" >/dev/null; then
+  echo "Unknown target '$TARGET'"
+  exit 1
+fi
+
+TARGET_BRANCH="$(jq -r --arg target "$TARGET" '.targets[$target].branch' "$SCRIPT_STASH/lts-backport.json")"
+DROP_UISCENE="$(jq -r --arg target "$TARGET" '.targets[$target].dropUiScene' "$SCRIPT_STASH/lts-backport.json")"
+NPM_TAG="$(jq -r --arg target "$TARGET" '.targets[$target].npmTag' "$SCRIPT_STASH/lts-backport.json")"
+SYNC_BRANCH="backport/main-to-${TARGET_BRANCH}"
+
+git fetch origin main "$TARGET_BRANCH"
+git checkout -B "$SYNC_BRANCH" "origin/${TARGET_BRANCH}"
+
+MAIN_VERSION="$(git show origin/main:package.json | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>console.log(JSON.parse(s).version))")"
+TARGET_VERSION="$(node -p "require('./package.json').version")"
+echo "main=$MAIN_VERSION ${TARGET_BRANCH}=$TARGET_VERSION"
+
+COMMIT_MESSAGE="chore: backport ${MAIN_VERSION} onto ${TARGET_BRANCH}"
+USED_PREFERRED_MERGE="false"
+
+if merge_main_preferred "$COMMIT_MESSAGE"; then
+  USED_PREFERRED_MERGE="true"
+else
+  git merge --abort || git reset --hard "origin/${TARGET_BRANCH}"
+fi
+
+UNMERGED="$(git diff --name-only --diff-filter=U || true)"
+if [ -n "$UNMERGED" ] || [ "$USED_PREFERRED_MERGE" != "true" ]; then
+  echo "Unable to complete merge of main into ${TARGET_BRANCH}"
+  ensure_sync_labels "${GITHUB_REPOSITORY}"
+  create_or_update_conflict_issue "${GITHUB_REPOSITORY}" \
+    "⚠️ LTS backport to ${TARGET_BRANCH} needs manual conflict resolution" \
+    "The scheduled backport of \`${MAIN_VERSION}\` onto \`${TARGET_BRANCH}\` could not be resolved with the main-preferred merge strategy plus LTS constraint restore. Manual resolution is required." \
+    "LTS backport to ${TARGET_BRANCH} needs manual conflict resolution in:title" || true
+  exit 1
+fi
+
+node "$RESTORE" --target "$TARGET" --repo-root "$ROOT"
+
+if command -v bun >/dev/null 2>&1; then
+  bun install
+  if [ -f example-app/package.json ]; then
+    (
+      cd example-app
+      bun install
+      bunx cap sync || echo "cap sync failed; lockfile and constraint restore still applied"
+    )
+  fi
+fi
+
+if [ "$DROP_UISCENE" = "true" ]; then
+  git checkout "origin/${TARGET_BRANCH}" -- \
+    example-app/ios/App/App/AppDelegate.swift \
+    example-app/ios/App/App/Info.plist \
+    example-app/ios/App/App.xcodeproj/project.pbxproj || true
+  if [ -f example-app/ios/App/App/SceneDelegate.swift ]; then
+    git rm -f example-app/ios/App/App/SceneDelegate.swift || rm -f example-app/ios/App/App/SceneDelegate.swift
+  fi
+fi
+
+git add -A
+if [ -n "$(git diff --name-only --diff-filter=U || true)" ]; then
+  echo "Constraint restore left unresolved files"
+  git diff --name-only --diff-filter=U
+  ensure_sync_labels "${GITHUB_REPOSITORY}"
+  git commit -am "chore: WIP backport ${MAIN_VERSION} onto ${TARGET_BRANCH} (unresolved constraints)" || true
+  git push origin "$SYNC_BRANCH" --force
+  PR_BODY=$(cat <<EOF
+## What
+- Attempted automatic backport of \`${MAIN_VERSION}\` onto \`${TARGET_BRANCH}\`
+
+## Why
+- LTS users need the latest Capgo updater on Capacitor $(jq -r --arg target "$TARGET" '.targets[$target].major' "$SCRIPT_STASH/lts-backport.json")
+
+## How
+- Merged \`main\` with a main-preferred conflict strategy, then restored pins from \`.github/lts-backport.json\`
+- Constraint restore could not finish; remaining conflict files need a human
+
+## Testing
+- Not run; merge is incomplete
+
+## Not Tested
+- Publish, native tests, Maestro
+EOF
+  )
+  EXISTING_PR="$(gh pr list --repo "${GITHUB_REPOSITORY}" --base "$TARGET_BRANCH" --head "$SYNC_BRANCH" --state open --json number -q '.[0].number' || true)"
+  if [ -z "$EXISTING_PR" ]; then
+    EXISTING_PR="$(create_pr_and_capture_number "${GITHUB_REPOSITORY}" "$TARGET_BRANCH" "$SYNC_BRANCH" "chore: backport ${MAIN_VERSION} to ${TARGET_BRANCH}" "$PR_BODY")"
+  fi
+  add_labels_to_pr "${GITHUB_REPOSITORY}" "$EXISTING_PR" lts-backport merge-conflict needs-attention || true
+  exit 1
+fi
+
+if ! git diff --cached --quiet; then
+  git commit -m "chore: restore Capacitor ${TARGET_BRANCH} constraints after backport ${MAIN_VERSION}"
+fi
+
+if [ "$(git rev-list --count "origin/${TARGET_BRANCH}..HEAD")" -eq 0 ]; then
+  echo "No backport needed for ${TARGET_BRANCH}; already up to date after constraint restore"
+  exit 0
+fi
+
+git push origin "$SYNC_BRANCH" --force
+echo "Pushed ${SYNC_BRANCH}"
+
+PR_BODY=$(cat <<EOF
+## What
+- Automatic backport of \`${MAIN_VERSION}\` onto \`${TARGET_BRANCH}\` as the matching LTS version
+- Restored Capacitor ${TARGET_BRANCH} pins from \`.github/lts-backport.json\`
+
+## Why
+- LTS users should get the latest Capgo updater without waiting on manual merge
+
+## How
+- Merged \`main\` with a main-preferred conflict strategy (same approach as capacitor-plus)
+- Reapplied major-specific Capacitor, iOS, Android, and example-app constraints
+- Direct-push to \`${TARGET_BRANCH}\` so \`bump_version.yml\` can test, tag, and publish \`${NPM_TAG}\`
+
+## Testing
+- Constraint restore self-test
+- \`bump_version.yml\` on \`${TARGET_BRANCH}\` runs the full test workflow before tagging
+
+## Not Tested
+- Live npm publish until the tag job finishes
+EOF
+)
+
+# Direct push to the LTS branch so bump_version.yml can test, tag, and publish.
+if git push origin "HEAD:${TARGET_BRANCH}"; then
+  echo "Pushed backport to ${TARGET_BRANCH}. bump_version.yml will tag ${NPM_TAG} after tests pass."
+  ensure_sync_labels "${GITHUB_REPOSITORY}"
+  EXISTING_PR="$(gh pr list --repo "${GITHUB_REPOSITORY}" --base "$TARGET_BRANCH" --head "$SYNC_BRANCH" --state open --json number -q '.[0].number' || true)"
+  if [ -n "$EXISTING_PR" ]; then
+    gh pr comment "$EXISTING_PR" --body "Automatic backport succeeded and was pushed directly to \`${TARGET_BRANCH}\`. Closing this PR." >/dev/null 2>&1 || true
+    gh pr close "$EXISTING_PR" >/dev/null 2>&1 || true
+  fi
+else
+  echo "Direct push to ${TARGET_BRANCH} failed; opening a PR instead"
+  ensure_sync_labels "${GITHUB_REPOSITORY}"
+  EXISTING_PR="$(gh pr list --repo "${GITHUB_REPOSITORY}" --base "$TARGET_BRANCH" --head "$SYNC_BRANCH" --state open --json number -q '.[0].number' || true)"
+  if [ -z "$EXISTING_PR" ]; then
+    EXISTING_PR="$(create_pr_and_capture_number "${GITHUB_REPOSITORY}" "$TARGET_BRANCH" "$SYNC_BRANCH" "chore: backport ${MAIN_VERSION} to ${TARGET_BRANCH}" "$PR_BODY")"
+  fi
+  add_labels_to_pr "${GITHUB_REPOSITORY}" "$EXISTING_PR" lts-backport automated || true
+  gh pr merge "$EXISTING_PR" --repo "${GITHUB_REPOSITORY}" --squash --auto >/dev/null 2>&1 || true
+fi

--- a/.github/scripts/restore-lts-constraints.mjs
+++ b/.github/scripts/restore-lts-constraints.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+/**
+ * Restore Capacitor-major pins after merging main into an LTS branch.
+ * Config: .github/lts-backport.json
+ *
+ * Usage:
+ *   node restore-lts-constraints.mjs --target v7
+ *   node restore-lts-constraints.mjs --self-test
+ */
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import assert from 'node:assert/strict';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(SCRIPT_DIR, '..', '..');
+const CONFIG_PATH = join(SCRIPT_DIR, '..', 'lts-backport.json');
+
+const CAPACITOR_DEP_PREFIX = '@capacitor/';
+const NATIVE_PLUGIN_VERSION_FILES = [
+  'android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java',
+  'ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift',
+];
+
+export function loadConfig(configPath = CONFIG_PATH) {
+  return JSON.parse(readFileSync(configPath, 'utf8'));
+}
+
+export function ltsVersionFromMain(mainVersion, targetMajor) {
+  const parts = String(mainVersion).split('.');
+  if (parts.length < 3 || parts.some((part) => !/^\d+$/.test(part))) {
+    throw new Error(`Unexpected version "${mainVersion}"`);
+  }
+  return `${targetMajor}.${parts[1]}.${parts[2]}`;
+}
+
+function pinCapacitorDeps(deps, range, extra = {}) {
+  if (!deps) {
+    return deps;
+  }
+  const next = { ...deps };
+  for (const key of Object.keys(next)) {
+    if (key === '@capacitor/docgen') {
+      if (extra.docgen) {
+        next[key] = extra.docgen;
+      }
+      continue;
+    }
+    if (key.startsWith(CAPACITOR_DEP_PREFIX)) {
+      next[key] = range;
+    }
+  }
+  return next;
+}
+
+export function rewritePackageJson(pkg, target, nextVersion) {
+  const extra = target.docgen ? { docgen: target.docgen } : {};
+  return {
+    ...pkg,
+    version: nextVersion,
+    devDependencies: pinCapacitorDeps(pkg.devDependencies, target.capacitorRange, extra),
+    dependencies: pinCapacitorDeps(pkg.dependencies, target.capacitorRange, extra),
+    peerDependencies: pinCapacitorDeps(pkg.peerDependencies, target.capacitorRange, extra),
+  };
+}
+
+export function rewriteExamplePackageJson(pkg, target) {
+  const extra = {};
+  return {
+    ...pkg,
+    dependencies: pinCapacitorDeps(pkg.dependencies, target.capacitorRange, extra),
+    devDependencies: pinCapacitorDeps(pkg.devDependencies, target.capacitorRange, extra),
+  };
+}
+
+export function patchAndroidBuildGradle(src, android) {
+  let out = src;
+  out = out.replace(
+    /compileSdk(?:Version)?(?:\s*=)?\s*project\.hasProperty\('compileSdkVersion'\) \? rootProject\.ext\.compileSdkVersion : \d+/,
+    (match) => match.replace(/: \d+$/, `: ${android.compileSdk}`),
+  );
+  out = out.replace(
+    /minSdkVersion(?:\s*=)?\s*project\.hasProperty\('minSdkVersion'\) \? rootProject\.ext\.minSdkVersion : \d+/,
+    (match) => match.replace(/: \d+$/, `: ${android.minSdk}`),
+  );
+  out = out.replace(
+    /targetSdkVersion(?:\s*=)?\s*project\.hasProperty\('targetSdkVersion'\) \? rootProject\.ext\.targetSdkVersion : \d+/,
+    (match) => match.replace(/: \d+$/, `: ${android.targetSdk}`),
+  );
+  out = out.replace(/sourceCompatibility JavaVersion\.VERSION_\d+/, `sourceCompatibility JavaVersion.VERSION_${android.java}`);
+  out = out.replace(/targetCompatibility JavaVersion\.VERSION_\d+/, `targetCompatibility JavaVersion.VERSION_${android.java}`);
+  out = out.replace(
+    /implementation 'com\.squareup\.okhttp3:okhttp:[^']+'/,
+    `implementation 'com.squareup.okhttp3:okhttp:${android.okhttp}'`,
+  );
+  out = out.replace(
+    /classpath 'com\.android\.tools\.build:gradle:[^']+'/,
+    `classpath 'com.android.tools.build:gradle:${android.agp}'`,
+  );
+  return out;
+}
+
+export function patchExampleVariablesGradle(src, android) {
+  let out = src;
+  out = out.replace(/minSdkVersion = \d+/, `minSdkVersion = ${android.minSdk}`);
+  out = out.replace(/compileSdkVersion = \d+/, `compileSdkVersion = ${android.compileSdk}`);
+  out = out.replace(/targetSdkVersion = \d+/, `targetSdkVersion = ${android.targetSdk}`);
+  return out;
+}
+
+export function patchPackageSwift(src, target) {
+  let out = src;
+  out = out.replace(/platforms:\s*\[\.iOS\([^)]+\)\]/, `platforms: [.iOS(${target.iosPlatform})]`);
+  out = out.replace(
+    /ionic-team\/capacitor-swift-pm\.git",\s*(?:from|exact):\s*"[^"]+"/,
+    `ionic-team/capacitor-swift-pm.git", from: "${target.swiftPm}"`,
+  );
+  if (target.bigIntExact) {
+    out = out.replace(
+      /\.package\(url: "https:\/\/github\.com\/attaswift\/BigInt\.git", [^)]+\)/,
+      `.package(url: "https://github.com/attaswift/BigInt.git", exact: "${target.bigIntExact}")`,
+    );
+  }
+  return out;
+}
+
+export function patchPodspec(src, target) {
+  return src.replace(/s\.ios\.deployment_target = '[^']+'/, `s.ios.deployment_target = '${target.iosDeployment}'`);
+}
+
+export function patchPluginVersion(src, fromVersion, toVersion) {
+  if (!fromVersion || fromVersion === toVersion) {
+    return src;
+  }
+  return src.split(fromVersion).join(toVersion);
+}
+
+function writeJson(path, value) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function readText(path) {
+  return readFileSync(path, 'utf8');
+}
+
+function writeText(path, value) {
+  writeFileSync(path, value);
+}
+
+export function applyConstraints(repoRoot, target) {
+  const pkgPath = join(repoRoot, 'package.json');
+  const pkg = JSON.parse(readText(pkgPath));
+  const fromVersion = pkg.version;
+  const toVersion = ltsVersionFromMain(fromVersion, target.major);
+  writeJson(pkgPath, rewritePackageJson(pkg, target, toVersion));
+
+  const examplePkgPath = join(repoRoot, 'example-app/package.json');
+  if (existsSync(examplePkgPath)) {
+    writeJson(examplePkgPath, rewriteExamplePackageJson(JSON.parse(readText(examplePkgPath)), target));
+  }
+
+  const gradlePath = join(repoRoot, 'android/build.gradle');
+  writeText(gradlePath, patchAndroidBuildGradle(readText(gradlePath), target.android));
+
+  const exampleGradlePath = join(repoRoot, 'example-app/android/build.gradle');
+  if (existsSync(exampleGradlePath)) {
+    writeText(
+      exampleGradlePath,
+      readText(exampleGradlePath).replace(
+        /classpath 'com\.android\.tools\.build:gradle:[^']+'/,
+        `classpath 'com.android.tools.build:gradle:${target.android.agp}'`,
+      ),
+    );
+  }
+
+  const exampleVarsPath = join(repoRoot, 'example-app/android/variables.gradle');
+  if (existsSync(exampleVarsPath)) {
+    writeText(exampleVarsPath, patchExampleVariablesGradle(readText(exampleVarsPath), target.android));
+  }
+
+  const swiftPath = join(repoRoot, 'Package.swift');
+  writeText(swiftPath, patchPackageSwift(readText(swiftPath), target));
+
+  const exampleSpmPath = join(repoRoot, 'example-app/ios/App/CapApp-SPM/Package.swift');
+  if (existsSync(exampleSpmPath)) {
+    writeText(exampleSpmPath, patchPackageSwift(readText(exampleSpmPath), target));
+  }
+
+  const podspecPath = join(repoRoot, 'CapgoCapacitorUpdater.podspec');
+  writeText(podspecPath, patchPodspec(readText(podspecPath), target));
+
+  for (const relative of NATIVE_PLUGIN_VERSION_FILES) {
+    const nativePath = join(repoRoot, relative);
+    if (existsSync(nativePath)) {
+      writeText(nativePath, patchPluginVersion(readText(nativePath), fromVersion, toVersion));
+    }
+  }
+
+  return { fromVersion, toVersion };
+}
+
+function selfTest() {
+  const rewritten = rewritePackageJson(
+    {
+      version: '8.51.15',
+      devDependencies: {
+        '@capacitor/core': '^8.5.0',
+        '@capacitor/docgen': '^0.3.0',
+        typescript: '^5.9.2',
+      },
+      peerDependencies: { '@capacitor/core': '^8.0.0' },
+    },
+    { major: 7, capacitorRange: '^7.0.0', docgen: '^0.2.1' },
+    '7.51.15',
+  );
+  assert.equal(rewritten.version, '7.51.15');
+  assert.equal(rewritten.devDependencies['@capacitor/core'], '^7.0.0');
+  assert.equal(rewritten.devDependencies['@capacitor/docgen'], '^0.2.1');
+  assert.equal(rewritten.devDependencies.typescript, '^5.9.2');
+  assert.equal(rewritten.peerDependencies['@capacitor/core'], '^7.0.0');
+  assert.equal(ltsVersionFromMain('8.51.15', 5), '5.51.15');
+
+  const gradle = patchAndroidBuildGradle(
+    `
+    compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 36
+    minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 24
+    targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 36
+    sourceCompatibility JavaVersion.VERSION_21
+    targetCompatibility JavaVersion.VERSION_21
+    classpath 'com.android.tools.build:gradle:8.13.0'
+    implementation 'com.squareup.okhttp3:okhttp:5.4.0'
+    `,
+    { minSdk: 22, compileSdk: 34, targetSdk: 34, java: 17, okhttp: '4.12.0', agp: '8.7.2' },
+  );
+  assert.match(gradle, /: 34/);
+  assert.match(gradle, /minSdkVersion[^\n]+: 22/);
+  assert.match(gradle, /VERSION_17/);
+  assert.match(gradle, /okhttp:4\.12\.0/);
+  assert.match(gradle, /gradle:8\.7\.2/);
+
+  const swift = patchPackageSwift(
+    `platforms: [.iOS("15.0")],
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
+        .package(url: "https://github.com/attaswift/BigInt.git", from: "5.7.0")`,
+    { iosPlatform: '.v13', swiftPm: '6.0.0', bigIntExact: '5.2.0' },
+  );
+  assert.match(swift, /\.iOS\(\.v13\)/);
+  assert.match(swift, /from: "6\.0\.0"/);
+  assert.match(swift, /exact: "5\.2\.0"/);
+
+  const exampleSpm = patchPackageSwift(
+    `platforms: [.iOS(.v15)],
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.5.0")`,
+    { iosPlatform: '.v14', swiftPm: '7.0.0' },
+  );
+  assert.match(exampleSpm, /\.iOS\(\.v14\)/);
+  assert.match(exampleSpm, /from: "7\.0\.0"/);
+
+  const podspec = patchPodspec("s.ios.deployment_target = '15.0'", { iosDeployment: '14.0' });
+  assert.equal(podspec, "s.ios.deployment_target = '14.0'");
+
+  const native = patchPluginVersion('private let pluginVersion: String = "8.51.15"', '8.51.15', '7.51.15');
+  assert.equal(native, 'private let pluginVersion: String = "7.51.15"');
+
+  const config = loadConfig();
+  assert.ok(config.targets.v5 && config.targets.v6 && config.targets.v7);
+  console.log('restore-lts-constraints self-test passed');
+}
+
+function parseArgs(argv) {
+  const args = { target: null, selfTest: false, repoRoot: REPO_ROOT };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--self-test') {
+      args.selfTest = true;
+    } else if (arg === '--target') {
+      args.target = argv[i + 1];
+      i += 1;
+    } else if (arg === '--repo-root') {
+      args.repoRoot = argv[i + 1];
+      i += 1;
+    }
+  }
+  return args;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const isDirectRun = Boolean(process.argv[1]) && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (args.selfTest || args.target || isDirectRun) {
+  if (args.selfTest) {
+    selfTest();
+    process.exit(0);
+  }
+  if (!args.target) {
+    console.error('Usage: restore-lts-constraints.mjs --target v5|v6|v7');
+    process.exit(1);
+  }
+  const config = loadConfig();
+  const target = config.targets[args.target];
+  if (!target) {
+    console.error(`Unknown target "${args.target}". Valid: ${Object.keys(config.targets).join(', ')}`);
+    process.exit(1);
+  }
+  const result = applyConstraints(args.repoRoot, target);
+  console.log(`Restored ${args.target} constraints: ${result.fromVersion} -> ${result.toVersion}`);
+}

--- a/.github/scripts/sync-gh-helpers.sh
+++ b/.github/scripts/sync-gh-helpers.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Shared GitHub helpers for automated backport/sync workflows.
+
+set -euo pipefail
+
+ensure_repo_label() {
+  local repo="$1"
+  local name="$2"
+  local color="$3"
+  local description="$4"
+
+  if gh api "repos/${repo}/labels/${name}" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  gh label create "$name" \
+    --repo "$repo" \
+    --color "$color" \
+    --description "$description" >/dev/null 2>&1 || {
+    echo "Warning: could not create label '${name}'"
+    return 1
+  }
+}
+
+ensure_sync_labels() {
+  local repo="$1"
+
+  ensure_repo_label "$repo" automated 0e8a16 "Fully automated workflow-managed change" || true
+  ensure_repo_label "$repo" needs-attention b60205 "Needs human follow-up" || true
+  ensure_repo_label "$repo" merge-conflict d93f0b "Merge conflict detected during automation" || true
+  ensure_repo_label "$repo" lts-backport 1d76db "Automated backport from main onto an LTS Capacitor branch" || true
+}
+
+repo_has_issues() {
+  local repo="$1"
+  gh api "repos/${repo}" --jq '.has_issues' 2>/dev/null || echo "false"
+}
+
+create_pr_and_capture_number() {
+  local repo="$1"
+  local base="$2"
+  local head="$3"
+  local title="$4"
+  local body="$5"
+
+  gh pr create \
+    --repo "$repo" \
+    --base "$base" \
+    --head "$head" \
+    --title "$title" \
+    --body "$body" >/dev/null
+
+  gh pr list \
+    --repo "$repo" \
+    --state open \
+    --base "$base" \
+    --head "$head" \
+    --json number \
+    -q '.[0].number'
+}
+
+add_labels_to_pr() {
+  local repo="$1"
+  local pr_number="$2"
+  shift 2
+
+  if [ "$#" -eq 0 ]; then
+    return 0
+  fi
+
+  local csv
+  csv=$(printf '%s,' "$@")
+  csv=${csv%,}
+
+  gh pr edit "$pr_number" --repo "$repo" --add-label "$csv" >/dev/null 2>&1 || {
+    echo "Warning: could not add labels '${csv}' to PR #${pr_number}"
+    return 1
+  }
+}
+
+create_or_update_conflict_issue() {
+  local repo="$1"
+  local title="$2"
+  local body="$3"
+  local search_text="$4"
+
+  if [ "$(repo_has_issues "$repo")" != "true" ]; then
+    return 1
+  fi
+
+  local existing_issue
+  existing_issue=$(
+    gh issue list \
+      --repo "$repo" \
+      --state open \
+      --search "$search_text" \
+      --json number \
+      -q '.[0].number' 2>/dev/null || true
+  )
+
+  if [ -n "$existing_issue" ]; then
+    gh issue comment "$existing_issue" --repo "$repo" --body "$body" >/dev/null 2>&1 || return 1
+    echo "$existing_issue"
+    return 0
+  fi
+
+  gh issue create \
+    --repo "$repo" \
+    --title "$title" \
+    --body "$body" \
+    --label lts-backport \
+    --label merge-conflict \
+    --label needs-attention >/dev/null 2>&1 || return 1
+
+  gh issue list \
+    --repo "$repo" \
+    --state open \
+    --search "$search_text" \
+    --json number \
+    -q '.[0].number'
+}
+
+merge_main_preferred() {
+  local commit_message="$1"
+
+  if git merge origin/main --no-edit -m "$commit_message"; then
+    return 0
+  fi
+
+  git merge --abort || true
+
+  if git merge origin/main -X theirs --no-edit -m "$commit_message"; then
+    return 0
+  fi
+
+  local unmerged
+  unmerged=$(git diff --name-only --diff-filter=U || true)
+  if [ -z "$unmerged" ]; then
+    return 1
+  fi
+
+  local file
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    if git checkout --theirs -- "$file" 2>/dev/null; then
+      git add "$file"
+    elif git rm -f "$file" 2>/dev/null; then
+      :
+    else
+      return 1
+    fi
+  done <<< "$unmerged"
+
+  if [ -n "$(git diff --name-only --diff-filter=U || true)" ]; then
+    return 1
+  fi
+
+  if [ -f .git/MERGE_HEAD ]; then
+    git commit --no-edit || git commit -m "$commit_message"
+    return 0
+  fi
+
+  return 1
+}

--- a/.github/workflows/backport-lts.yml
+++ b/.github/workflows/backport-lts.yml
@@ -1,0 +1,77 @@
+name: Backport main to LTS
+
+on:
+  schedule:
+    # Daily at 6 AM UTC, same window as capacitor-plus sync
+    - cron: '0 6 * * *'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'example-app/**'
+      - '.github/**'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Which LTS branch to backport onto'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - v5
+          - v6
+          - v7
+
+jobs:
+  matrix:
+    if: github.event_name != 'push' || startsWith(github.event.head_commit.message, 'chore(release):')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      branches: ${{ steps.set.outputs.branches }}
+    steps:
+      - name: Resolve LTS targets
+        id: set
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.branch }}" != "all" ] && [ -n "${{ github.event.inputs.branch }}" ]; then
+            echo 'branches=["${{ github.event.inputs.branch }}"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'branches=["v5","v6","v7"]' >> "$GITHUB_OUTPUT"
+          fi
+
+  backport:
+    needs: matrix
+    if: needs.matrix.outputs.branches != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJSON(needs.matrix.outputs.branches) }}
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      - uses: oven-sh/setup-bun@v2
+      - name: Self-test constraint restore
+        run: node .github/scripts/restore-lts-constraints.mjs --self-test
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Backport main onto ${{ matrix.branch }}
+        env:
+          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: bash .github/scripts/backport-lts.sh "${{ matrix.branch }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,13 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Install npm CLI for staged publishing
         run: npm install -g npm@^11.15.0
+      - name: Stage publish lts-v5 to npm
+        if: ${{ startsWith(github.ref, 'refs/tags/5.') }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm --version
+          npm stage publish --tag lts-v5 --provenance --access public --ignore-scripts
       - name: Stage publish lts-v6 to npm
         if: ${{ startsWith(github.ref, 'refs/tags/6.') }}
         env:
@@ -56,15 +63,22 @@ jobs:
         run: |
           npm --version
           npm stage publish --tag lts-v6 --provenance --access public --ignore-scripts
+      - name: Stage publish lts-v7 to npm
+        if: ${{ startsWith(github.ref, 'refs/tags/7.') }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm --version
+          npm stage publish --tag lts-v7 --provenance --access public --ignore-scripts
       - name: Stage publish to npm
-        if: ${{ !contains(github.ref, '-alpha.') && !startsWith(github.ref, 'refs/tags/6.') }}
+        if: ${{ !contains(github.ref, '-alpha.') && !startsWith(github.ref, 'refs/tags/5.') && !startsWith(github.ref, 'refs/tags/6.') && !startsWith(github.ref, 'refs/tags/7.') }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npm --version
           npm stage publish --tag latest --provenance --access public --ignore-scripts
       - name: Stage publish to npm with next tag
-        if: ${{ contains(github.ref, '-alpha.') && !startsWith(github.ref, 'refs/tags/6.')  }}
+        if: ${{ contains(github.ref, '-alpha.') && !startsWith(github.ref, 'refs/tags/5.') && !startsWith(github.ref, 'refs/tags/6.') && !startsWith(github.ref, 'refs/tags/7.') }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
@@ -92,6 +106,6 @@ jobs:
             ---
 
             🔗 **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.changelog.outputs.from_tag || github.ref_name }}...${{ steps.changelog.outputs.to_tag || github.ref_name }}
-          make_latest: true
+          make_latest: ${{ !contains(github.ref, '-alpha.') && !startsWith(github.ref, 'refs/tags/5.') && !startsWith(github.ref, 'refs/tags/6.') && !startsWith(github.ref, 'refs/tags/7.') }}
           token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
           prerelease: ${{ contains(github.ref, '-alpha.') }}

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
       - development
+      - v5
+      - v6
+      - v7
     paths-ignore:
       - 'example-app/**'
       - '.github/**'
@@ -57,6 +60,21 @@ jobs:
       - name: Create version bump development
         if: github.ref == 'refs/heads/development'
         run: bunx capacitor-plugin-standard-version@2.0.19 --prerelease alpha --skip.changelog
+      - name: Tag existing version on LTS branches
+        if: github.ref == 'refs/heads/v5' || github.ref == 'refs/heads/v6' || github.ref == 'refs/heads/v7'
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          MAJOR=${VERSION%%.*}
+          if [ "$GITHUB_REF" != "refs/heads/v${MAJOR}" ]; then
+            echo "Ref $GITHUB_REF does not match package major $MAJOR"
+            exit 1
+          fi
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists"
+            exit 0
+          fi
+          git tag "$VERSION"
       - name: Push to origin
         run: |
           CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - renovate/**
   pull_request:
-    branches: [main]
+    branches: [main, v5, v6, v7]
   workflow_dispatch:
   workflow_call: # Allow this workflow to be called by other workflows
 
@@ -35,8 +35,9 @@ jobs:
       - name: Enforce capacitor-swift-pm version
         run: |
           set -euo pipefail
-          if ! grep -Eq 'https://github.com/ionic-team/capacitor-swift-pm\.git"[[:space:]]*,[[:space:]]*from:[[:space:]]*"8\.0\.0"' Package.swift; then
-            echo "Expected capacitor-swift-pm to be pinned to 8.0.0 in Package.swift"
+          MAJOR=$(awk -F'"' '/"version":/{print $4; exit}' package.json | cut -d. -f1)
+          if ! grep -Eq "https://github.com/ionic-team/capacitor-swift-pm\\.git\"[[:space:]]*,[[:space:]]*from:[[:space:]]*\"${MAJOR}\\.0\\.0\"" Package.swift; then
+            echo "Expected capacitor-swift-pm to be pinned to ${MAJOR}.0.0 in Package.swift"
             exit 1
           fi
 
@@ -496,6 +497,8 @@ jobs:
           dependency-cache-path: node_modules
       - name: Check plugin wiring
         run: bun run check:wiring
+      - name: Self-test LTS constraint restore
+        run: bun .github/scripts/restore-lts-constraints.mjs --self-test
       - name: Lint
         id: lint_code
         run: bun run eslint && bun run prettier -- --check


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Add a daily (and post-release) workflow that backports `main` onto Capacitor LTS branches `v5`, `v6`, and `v7`
- Restore major-specific Capacitor / iOS / Android / example-app pins from `.github/lts-backport.json` after merge
- Publish LTS versions automatically: tag the restored `5.x` / `6.x` / `7.x` package version, then `npm stage publish` to `lts-v5` / `lts-v6` / `lts-v7`

## Why
- Manual backport PRs for 8.51.15 (#869, #870, #871) stayed unmerged, so LTS lines did not publish
- Plugin major must follow Capacitor major, but updater fixes should still land on old majors without hand-merging every release

## How
- Same merge-conflict approach as capacitor-plus: try a normal merge, then retry with main-preferred (`-X theirs`) and resolve leftover modify/delete conflicts
- `.github/lts-backport.json` is the instruction file for differences between Capacitor majors (ranges, iOS deployment, SwiftPM, minSdk/compileSdk/Java/OkHttp/AGP, UIScene)
- Clean backports are pushed directly to the LTS branch so `bump_version.yml` runs tests, tags the existing version (no `standard-version` bump), and `build.yml` publishes the matching `lts-v*` dist-tag
- Unresolved conflicts open a labeled PR/issue instead of publishing
- `build.yml` now publishes `5.*` / `6.*` / `7.*` tags to `lts-v5` / `lts-v6` / `lts-v7` and does not mark those GitHub releases as latest

## Testing
- `node .github/scripts/restore-lts-constraints.mjs --self-test`
- Applied restore onto copied main files: `8.51.15` → `7.51.15` / `6.51.15` / `5.51.15` with the expected Capacitor pins
- Dry-run merged `origin/main` into `v7` with the main-preferred strategy; conflicts resolved and constraints restored
- Workflow YAML parsed successfully

## Not Tested
- First live scheduled/dispatch run against `v5` / `v6` / `v7` (needs this workflow on `main`)
- Live npm `lts-v*` publish until a backport lands and `bump_version.yml` tags it
- Existing draft backports #869 / #870 / #871 can be closed once the first automatic run succeeds

After merge, run **Actions → Backport main to LTS → Run workflow** to backport immediately, or wait for the daily 06:00 UTC cron.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85baff83-e978-4551-bd1a-ed133f02bca8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85baff83-e978-4551-bd1a-ed133f02bca8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-updater/pr/875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790853009&installation_model_id=430928&pr_number=875&repository=Cap-go%2Fcapacitor-updater&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-updater%2Fpull%2F875&signature=61d6d9bd743ee9f68e6c7b5bdc6e4af9ec82eeed9ce543363a5f0d7286aecbe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-updater/pull/875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

