### PR TITLE
fix(android): raise v6 minSdk to 23 so lts-v6 can publish

### DIFF
--- a/.github/lts-backport.json
+++ b/.github/lts-backport.json
@@ -31,9 +31,9 @@
       "bigIntExact": "5.2.0",
       "dropUiScene": true,
       "android": {
-        "minSdk": 22,
-        "compileSdk": 34,
-        "targetSdk": 34,
+        "minSdk": 23,
+        "compileSdk": 35,
+        "targetSdk": 35,
         "java": 17,
         "okhttp": "4.12.0",
         "agp": "8.7.2"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ android {
     namespace "ee.forgr.capacitor_updater"
     compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 35
     defaultConfig {
-        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22
+        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 23
         targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 35
         versionCode 1
         versionName "1.0"

--- a/example-app/android/variables.gradle
+++ b/example-app/android/variables.gradle
@@ -1,5 +1,5 @@
 ext {
-    minSdkVersion = 22
+    minSdkVersion = 23
     compileSdkVersion = 35
     targetSdkVersion = 35
     androidxActivityVersion = '1.9.2'


### PR DESCRIPTION
## What
- Raise Capacitor 6 plugin and example `minSdk` from 22 to 23
- Keep the v6 LTS pin at compileSdk/targetSdk 35 (AndroidX already needs that)

## Why
- `lts-v6` is stuck on **6.50.2** even though git is already **6.51.15**
- CI `build_android` fails: `play-services-tasks:18.4.1` cannot merge into minSdk 22
- No tag is created until tests pass, so npm never publishes `6.51.15`

## How
- Plugin default minSdk and example-app `variables.gradle` both go to 23
- `.github/lts-backport.json` v6 pin matches so the next auto-backport does not revert this

## Testing
- GitHub Actions on this PR (`build_android` was the failing job)

## Not Tested
- Live `npm stage publish --tag lts-v6` until this merges and `bump_version.yml` tags `6.51.15`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-updater/pr/878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790946083&installation_model_id=430928&pr_number=878&repository=Cap-go%2Fcapacitor-updater&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-updater%2Fpull%2F878&signature=31149fe7b0651329c7e163014218f7e2b2f60938d685a0a6dbffb45dadda902a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-updater/pull/878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

