### PR TITLE
fix(android): keep unexpired background delay on foreground resume

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/DelayUpdateUtils.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DelayUpdateUtils.java
@@ -75,6 +75,17 @@ public class DelayUpdateUtils {
                                     ", longValue: " +
                                     longValue
                             );
+                        } else {
+                            delayConditionListToKeep.add(condition);
+                            logger.info(
+                                "Background delay (value: " +
+                                    value +
+                                    ") condition kept at index " +
+                                    index +
+                                    " (source: " +
+                                    source.toString() +
+                                    ")"
+                            );
                         }
                     } else {
                         delayConditionListToKeep.add(condition);

--- a/android/src/test/java/ee/forgr/capacitor_updater/DelayUpdateUtilsTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/DelayUpdateUtilsTest.java
@@ -83,6 +83,27 @@ public class DelayUpdateUtilsTest {
     }
 
     @Test
+    public void checkCancelDelay_foregroundKeepsUnexpiredBackgroundCondition() throws Exception {
+        JSONArray stored = new JSONArray();
+        stored.put(new JSONObject().put("kind", "background").put("value", "60000"));
+        when(prefs.getString(eq(DelayUpdateUtils.DELAY_CONDITION_PREFERENCES), anyString())).thenReturn(stored.toString());
+        when(prefs.getLong(eq(DelayUpdateUtils.BACKGROUND_TIMESTAMP_KEY), anyLong())).thenReturn(System.currentTimeMillis() - 1000L);
+
+        utils.checkCancelDelay(DelayUpdateUtils.CancelDelaySource.FOREGROUND);
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(editor).putString(eq(DelayUpdateUtils.DELAY_CONDITION_PREFERENCES), captor.capture());
+        verify(editor).commit();
+        verify(editor, never()).remove(eq(DelayUpdateUtils.DELAY_CONDITION_PREFERENCES));
+
+        JSONArray updated = new JSONArray(captor.getValue());
+        assertEquals(1, updated.length());
+        JSONObject remaining = updated.getJSONObject(0);
+        assertEquals("background", remaining.getString("kind"));
+        assertEquals("60000", remaining.getString("value"));
+    }
+
+    @Test
     public void checkCancelDelay_foregroundRemovesExpiredBackgroundCondition() throws Exception {
         JSONArray stored = new JSONArray();
         stored.put(new JSONObject().put("kind", "background").put("value", "1"));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Fix Android `DelayUpdateUtils.checkCancelDelay` so an unexpired `background` delay is kept when the app resumes to foreground.
- Add a unit test covering the unexpired foreground keep path.

## Why
- Commit `cb57e00a` added a `break` after logging expired background delays but omitted the iOS keep-else branch.
- On foreground resume, Android dropped still-valid background delays because they were never added to `delayConditionListToKeep`, leaving the list empty and triggering `cancelDelay`.

## How
- Mirror iOS `DelayUpdateUtils.swift` (lines 75–82): when `delta <= longValue`, add the background condition to `delayConditionListToKeep`.
- Add `checkCancelDelay_foregroundKeepsUnexpiredBackgroundCondition` with a recent background timestamp and a 60s delay value.

## Testing
- Added `checkCancelDelay_foregroundKeepsUnexpiredBackgroundCondition` in `DelayUpdateUtilsTest.java`.
- Existing `checkCancelDelay_foregroundRemovesExpiredBackgroundCondition` still covers the expired path.
- iOS code unchanged.

## Not Tested
- Manual device verification of foreground/background apply timing (README still documents apply on next background/restart; no `installNext()` change).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-291379e8-2f3a-47b8-89ee-d5591105ee61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-291379e8-2f3a-47b8-89ee-d5591105ee61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-updater/pr/879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791005306&installation_model_id=430928&pr_number=879&repository=Cap-go%2Fcapacitor-updater&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-updater%2Fpull%2F879&signature=c286822cbe6fde342b6b5cbf23476e0a3fd110b03d80e1d1e4d29555e26d4796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-updater/pull/879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Background update delay conditions are now retained correctly when foreground cancellation occurs before the delay expires.
  - Unexpired delay settings are preserved instead of being omitted or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->