### PR TITLE
fix(ios): reuse decoded builtin files for Brotli manifests

### DIFF
--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -219,7 +219,8 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     // Best-effort flag: set before we expect notifyAppReady (load/reload).
     // No lock — never held across waits; a rare race only mis-times one wait.
     private var pendingNotifyAppReady = false
-    private(set) var didEnterSemaphoreWaitForTesting = false
+    private let semaphoreWaitTestingLock = NSLock()
+    private var didEnterSemaphoreWaitForTesting = false
 
     private var delayUpdateUtils: DelayUpdateUtils!
 
@@ -598,7 +599,9 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private func semaphoreWait(waitTime: Int) {
         // print("\\(CapgoUpdater.TAG) semaphoreWait \\(waitTime)")
+        semaphoreWaitTestingLock.lock()
         didEnterSemaphoreWaitForTesting = true
+        semaphoreWaitTestingLock.unlock()
         let result = semaphoreReady.wait(timeout: .now() + .milliseconds(waitTime))
         if result == .timedOut {
             logger.error("Semaphore wait timed out after \(waitTime)ms")
@@ -4109,11 +4112,15 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     func resetSemaphoreWaitTestingStateForTesting() {
+        semaphoreWaitTestingLock.lock()
         didEnterSemaphoreWaitForTesting = false
+        semaphoreWaitTestingLock.unlock()
     }
 
     var didEnterSemaphoreWaitForTestingState: Bool {
-        didEnterSemaphoreWaitForTesting
+        semaphoreWaitTestingLock.lock()
+        defer { semaphoreWaitTestingLock.unlock() }
+        return didEnterSemaphoreWaitForTesting
     }
 
     func clearPendingNotifyAppReadyForTesting() {

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -219,6 +219,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     // Best-effort flag: set before we expect notifyAppReady (load/reload).
     // No lock — never held across waits; a rare race only mis-times one wait.
     private var pendingNotifyAppReady = false
+    private(set) var didEnterSemaphoreWaitForTesting = false
 
     private var delayUpdateUtils: DelayUpdateUtils!
 
@@ -597,6 +598,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private func semaphoreWait(waitTime: Int) {
         // print("\\(CapgoUpdater.TAG) semaphoreWait \\(waitTime)")
+        didEnterSemaphoreWaitForTesting = true
         let result = semaphoreReady.wait(timeout: .now() + .milliseconds(waitTime))
         if result == .timedOut {
             logger.error("Semaphore wait timed out after \(waitTime)ms")
@@ -4104,6 +4106,14 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
 
     func armPendingNotifyAppReadyForTesting() {
         pendingNotifyAppReady = true
+    }
+
+    func resetSemaphoreWaitTestingStateForTesting() {
+        didEnterSemaphoreWaitForTesting = false
+    }
+
+    var didEnterSemaphoreWaitForTestingState: Bool {
+        didEnterSemaphoreWaitForTesting
     }
 
     func clearPendingNotifyAppReadyForTesting() {

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -1231,7 +1231,10 @@ import UIKit
         }
 
         let builtinFolder = self.builtinFolderURL()
-        let builtinFilePath = builtinFolder.appendingPathComponent(fileName)
+        // The .br suffix describes transport; builtin assets are uncompressed.
+        guard let builtinFilePath = try? Self.resolveManifestTargetPath(baseDirectory: builtinFolder, fileName: fileName) else {
+            return false
+        }
         if FileManager.default.fileExists(atPath: builtinFilePath.path) && verifyChecksum(file: builtinFilePath, expectedHash: fileHash) {
             return true
         }
@@ -1474,7 +1477,7 @@ import UIKit
             let builtinFilePath: URL
             do {
                 destFilePath = try Self.resolveManifestTargetPath(baseDirectory: destFolder, fileName: fileName)
-                builtinFilePath = try Self.resolvePathInsideDirectory(baseDirectory: builtinFolder, relativePath: fileName)
+                builtinFilePath = try Self.resolveManifestTargetPath(baseDirectory: builtinFolder, fileName: fileName)
             } catch {
                 logger.error("Invalid manifest file path: \(fileName)")
                 self.sendStats(action: "manifest_path_fail", versionName: "\(version):\(fileName)")

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -928,10 +928,7 @@ import UIKit
 
     struct ManifestLookupEntry {
         let hash: String
-        /// The manifest's own file name, `.br` suffix included when present. The
-        /// built-in bundle stores files under this exact name (see
-        /// isManifestEntryAvailableLocally), unlike the extracted/cached copy which
-        /// is always named without the suffix.
+        /// The manifest's own file name, `.br` suffix included when present.
         let originalFileName: String
     }
 
@@ -994,10 +991,14 @@ import UIKit
 
             // Builtin is already a permanent reuse source (see isManifestEntryAvailableLocally),
             // so there's no need to also duplicate this file into the delta cache
-            let builtinRelativePath = knownEntry?.originalFileName ?? relativePath
-            let builtinFilePath = builtinFolder.appendingPathComponent(builtinRelativePath)
-            let isBuiltinOrigin = fileManager.fileExists(atPath: builtinFilePath.path) &&
-                verifyChecksum(file: builtinFilePath, expectedHash: checksum)
+            let builtinLookupName = knownEntry?.originalFileName ?? relativePath
+            let isBuiltinOrigin: Bool
+            if let builtinFilePath = try? Self.resolveManifestTargetPath(baseDirectory: builtinFolder, fileName: builtinLookupName) {
+                isBuiltinOrigin = fileManager.fileExists(atPath: builtinFilePath.path) &&
+                    verifyChecksum(file: builtinFilePath, expectedHash: checksum)
+            } else {
+                isBuiltinOrigin = false
+            }
             if isBuiltinOrigin {
                 continue
             }

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -37,6 +37,13 @@ private final class RealSendReadyCapacitorUpdaterPlugin: CapacitorUpdaterPlugin 
     private let eventLock = NSLock()
     private var _notifiedEventNames: [String] = []
     private var _notifiedEventPayloads: [String: [String: Any]] = [:]
+    private var _appReadyNotifiedAt: Date?
+
+    var appReadyNotifiedAt: Date? {
+        eventLock.lock()
+        defer { eventLock.unlock() }
+        return _appReadyNotifiedAt
+    }
 
     var notifiedEventNames: [String] {
         eventLock.lock()
@@ -53,6 +60,9 @@ private final class RealSendReadyCapacitorUpdaterPlugin: CapacitorUpdaterPlugin 
     override func notifyListeners(_ eventName: String, data: [String: Any]?, retainUntilConsumed _: Bool) {
         eventLock.lock()
         _notifiedEventNames.append(eventName)
+        if eventName == "appReady" {
+            _appReadyNotifiedAt = Date()
+        }
         if let data {
             _notifiedEventPayloads[eventName] = data
         }
@@ -2968,8 +2978,8 @@ class CapacitorUpdaterTests: XCTestCase {
 
     func testSendReadyToJsUnblocksWhenNotifyAppReadySignals() {
         let testPlugin = RealSendReadyCapacitorUpdaterPlugin()
-        let waitTimeoutMs = 500
-        testPlugin.setAppReadyTimeoutForTesting(waitTimeoutMs)
+        testPlugin.setAppReadyTimeoutForTesting(500)
+        testPlugin.resetSemaphoreWaitTestingStateForTesting()
         testPlugin.armPendingNotifyAppReadyForTesting()
         let bundle = BundleInfo(
             id: BundleInfo.ID_BUILTIN,
@@ -2983,26 +2993,27 @@ class CapacitorUpdaterTests: XCTestCase {
         testPlugin.sendReadyToJs(current: bundle, msg: "update installed")
 
         DispatchQueue.global().async {
-            // Wait until sendReadyToJs consumes the armed flag and enters semaphoreWait.
-            // CI can delay DispatchQueue.global work; measuring from test start includes that
-            // scheduling latency and flakes. Signal only once the wait is armed.
-            var waitStarted = Date()
+            // Wait until sendReadyToJs enters semaphoreWait. The armed flag is cleared
+            // before the wait starts, so polling that flag can signal too early.
             for _ in 0..<400 {
-                if !testPlugin.isPendingNotifyAppReadyForTesting {
-                    waitStarted = Date()
+                if testPlugin.didEnterSemaphoreWaitForTestingState {
                     break
                 }
                 Thread.sleep(forTimeInterval: 0.01)
             }
+            XCTAssertTrue(testPlugin.didEnterSemaphoreWaitForTestingState)
 
             let signalStart = Date()
             // Simulate notifyAppReady signalling the semaphore.
             testPlugin.semaphoreReady.signal()
 
             for _ in 0..<80 {
-                if testPlugin.notifiedEventNames.contains("appReady") {
-                    XCTAssertLessThan(Date().timeIntervalSince(signalStart), 0.5)
-                    XCTAssertLessThan(Date().timeIntervalSince(waitStarted), Double(waitTimeoutMs) / 1000.0)
+                if let notifiedAt = testPlugin.appReadyNotifiedAt {
+                    XCTAssertGreaterThanOrEqual(
+                        notifiedAt.timeIntervalSince1970,
+                        signalStart.timeIntervalSince1970
+                    )
+                    XCTAssertLessThan(notifiedAt.timeIntervalSince(signalStart), 0.5)
                     expectation.fulfill()
                     return
                 }

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -2968,7 +2968,8 @@ class CapacitorUpdaterTests: XCTestCase {
 
     func testSendReadyToJsUnblocksWhenNotifyAppReadySignals() {
         let testPlugin = RealSendReadyCapacitorUpdaterPlugin()
-        testPlugin.setAppReadyTimeoutForTesting(2000)
+        let waitTimeoutMs = 500
+        testPlugin.setAppReadyTimeoutForTesting(waitTimeoutMs)
         testPlugin.armPendingNotifyAppReadyForTesting()
         let bundle = BundleInfo(
             id: BundleInfo.ID_BUILTIN,
@@ -2979,17 +2980,29 @@ class CapacitorUpdaterTests: XCTestCase {
         )
 
         let expectation = expectation(description: "appReady after notify")
-        let start = Date()
         testPlugin.sendReadyToJs(current: bundle, msg: "update installed")
 
-        DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
+        DispatchQueue.global().async {
+            // Wait until sendReadyToJs consumes the armed flag and enters semaphoreWait.
+            // CI can delay DispatchQueue.global work; measuring from test start includes that
+            // scheduling latency and flakes. Signal only once the wait is armed.
+            var waitStarted = Date()
+            for _ in 0..<400 {
+                if !testPlugin.isPendingNotifyAppReadyForTesting {
+                    waitStarted = Date()
+                    break
+                }
+                Thread.sleep(forTimeInterval: 0.01)
+            }
+
+            let signalStart = Date()
             // Simulate notifyAppReady signalling the semaphore.
             testPlugin.semaphoreReady.signal()
-        }
 
-        DispatchQueue.global().async {
             for _ in 0..<80 {
                 if testPlugin.notifiedEventNames.contains("appReady") {
+                    XCTAssertLessThan(Date().timeIntervalSince(signalStart), 0.5)
+                    XCTAssertLessThan(Date().timeIntervalSince(waitStarted), Double(waitTimeoutMs) / 1000.0)
                     expectation.fulfill()
                     return
                 }
@@ -2997,8 +3010,7 @@ class CapacitorUpdaterTests: XCTestCase {
             }
         }
 
-        wait(for: [expectation], timeout: 2.0)
-        XCTAssertLessThan(Date().timeIntervalSince(start), 1.0)
+        wait(for: [expectation], timeout: 5.0)
         XCTAssertFalse(testPlugin.isPendingNotifyAppReadyForTesting)
     }
 

--- a/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
@@ -325,6 +325,57 @@ final class PopulateDeltaCacheTests: XCTestCase {
     }
 }
 
+extension PopulateDeltaCacheTests {
+    func testGetMissingBundleFilesReusesUncompressedBuiltinForBrotliEntry() throws {
+        let testId = try XCTUnwrap(bundleId)
+        let name = "\(testId).js"
+        let source = try write("builtin \(testId)", named: name, in: builtinFolder.appendingPathComponent("assets"))
+        let hash = CryptoCipher.calcChecksum(filePath: source)
+        let manifest = [ManifestEntry(file_name: "assets/\(name).br", file_hash: hash, download_url: nil)]
+
+        XCTAssertTrue(implementation.getMissingBundleFiles(manifest: manifest, sessionKey: "").isEmpty)
+
+        // A decoded filename match alone must not bypass checksum verification.
+        try "different content".write(to: source, atomically: true, encoding: .utf8)
+        XCTAssertEqual(implementation.getMissingBundleFiles(manifest: manifest, sessionKey: "").count, 1)
+    }
+
+    func testDownloadManifestReusesSignedUncompressedBuiltinForBrotliEntry() throws {
+        implementation.setLogger(Logger(withTag: "BrotliBuiltinTest", options: Logger.Options(level: .silent)))
+        implementation.setPublicKey(Fixture.publicKeyPem)
+        let name = "\(try XCTUnwrap(bundleId)).js"
+        let source = try write("", named: name, in: builtinFolder.appendingPathComponent("assets"))
+        let (signedHash, plainHash) = Fixture.firstDecryptChecksumCase
+        XCTAssertEqual(CryptoCipher.calcChecksum(filePath: source), plainHash)
+        let manifest = [ManifestEntry(
+            file_name: "assets/\(name).br",
+            file_hash: signedHash,
+            // Invalid URL makes any attempted download fail immediately: this must reuse builtin.
+            download_url: "http://["
+        )]
+
+        // Only checksum recovery is needed when builtin matches; no file/session decryption occurs.
+        let result = try implementation.downloadManifest(manifest: manifest, version: "1.0.0", sessionKey: "signed-manifest")
+        defer {
+            _ = implementation.delete(id: result.getId(), removeInfo: true)
+            implementation.shutdown()
+        }
+        let destination = implementation.getBundleDirectory(id: result.getId())
+        XCTAssertEqual(try Data(contentsOf: destination.appendingPathComponent("assets/\(name)")), Data())
+        XCTAssertFalse(FileManager.default.fileExists(atPath: destination.appendingPathComponent("assets/\(name).br").path))
+    }
+
+    func testMissingBrotliEntryCannotReuseFileOutsideBuiltin() throws {
+        let name = "\(try XCTUnwrap(bundleId))-outside.js"
+        let source = try write("outside", named: name, in: builtinFolder.deletingLastPathComponent())
+        defer { try? FileManager.default.removeItem(at: source) }
+        let hash = CryptoCipher.calcChecksum(filePath: source)
+        let manifest = [ManifestEntry(file_name: "../\(name).br", file_hash: hash, download_url: nil)]
+
+        XCTAssertEqual(implementation.getMissingBundleFiles(manifest: manifest, sessionKey: "").count, 1)
+    }
+}
+
 final class IoBufferSizeTests: XCTestCase {
     func testIoBuffersAre256KiBForChecksumAndCopy() {
         XCTAssertEqual(CryptoCipher.ioBufferBytes(), 256 * 1024)

--- a/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
@@ -136,8 +136,6 @@ final class PopulateDeltaCacheTests: XCTestCase {
         let lookup = implementation.manifestHashLookup(manifest: manifest, sessionKey: "")
 
         XCTAssertEqual(lookup["assets/app.js"]?.hash, "plainhash")
-        // The original (unstripped) manifest name must be preserved — it's what the
-        // built-in bundle actually stores the file under.
         XCTAssertEqual(lookup["assets/app.js"]?.originalFileName, "assets/app.js.br")
         XCTAssertNil(lookup["assets/app.js.br"])
     }
@@ -215,16 +213,14 @@ final class PopulateDeltaCacheTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: cacheFile.path))
     }
 
-    /// Regression test: the built-in bundle stores brotli manifest entries under
-    /// their original (`.br`-suffixed) name, while the extracted bundle file on disk
-    /// is always named without it. The builtin lookup must resolve against the
-    /// manifest's original name, not the extracted file's own path, or this match
-    /// silently never fires for any compressed asset.
+    /// Regression test: brotli manifest entries are extracted without the `.br`
+    /// suffix, while builtin assets are stored uncompressed. populateDeltaCache must
+    /// resolve the builtin path the same way as isManifestEntryAvailableLocally.
     func testPopulateDeltaCacheSkipsBrotliFilesAlreadyAvailableFromBuiltin() throws {
         let content = "shared builtin content \(bundleId!)"
         let extractedFileURL = try write(content, named: "app.js", in: bundleDir.appendingPathComponent("assets"))
         let realHash = CryptoCipher.calcChecksum(filePath: extractedFileURL)
-        try write(content, named: "app.js.br", in: builtinFolder.appendingPathComponent("assets"))
+        try write(content, named: "app.js", in: builtinFolder.appendingPathComponent("assets"))
         let manifest = [
             ManifestEntry(file_name: "assets/app.js.br", file_hash: realHash, download_url: nil)
         ]


### PR DESCRIPTION
Closes #886

## What

Let iOS reuse an uncompressed builtin asset for a Brotli manifest entry. For example, `assets/app.js.br` now checks builtin `assets/app.js` in both manifest assembly and the missing-files query.

## Why

The CLI signs the uncompressed hash, then compresses/encrypts the file and adds `.br` to its manifest filename. The iOS destination already removes that suffix, but the builtin lookup previously used the transport filename. This forced otherwise identical builtin files to download.

## How

Use the existing `resolveManifestTargetPath` helper for builtin paths, preserving directory-boundary validation and SHA-256 verification. Download, AES decryption, Brotli decompression, and decoded checksum comparison remain unchanged. There are no JavaScript API or wire-format changes.

## Testing

- `bun run verify` passed: iOS, Android (Java 21), and web builds, including Android unit tests.
- `bun run fmt` completed.
- Both new builtin-reuse regression tests fail on unpatched upstream: the missing-files query reports the entry missing, and manifest assembly attempts the deliberately invalid download URL.
- With the fix, 17 iOS cache/reuse/path tests passed. They cover a signed Brotli manifest entry reusing builtin with no network access, a changed builtin hash remaining missing, and rejection of a path outside builtin.
- Full `bun run lint` remains nonzero on untouched upstream as well. No additional lint violations were introduced; the new code passes the comparison against the same upstream lint configuration.

## Not Tested

Complete Internet-to-first-render latency, older physical devices/iOS versions, or Android runtime performance. Android already strips `.br` for its builtin asset lookup and is unchanged. Existing installed iOS binaries require a native update to receive this fix.

Prepared with AI assistance; the measurements and checks above were run locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-updater/pr/888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791428346&installation_model_id=430928&pr_number=888&repository=Cap-go%2Fcapacitor-updater&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-updater%2Fpull%2F888&signature=9926397c6036137e0350a7c7af84542b581d0d7ee66f5ef6fa7b32037557e50b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-updater/pull/888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Brotli-compressed manifest entries when matching built-in files.
  * Ensured uncompressed built-in files are reused only when their checksums match.
  * Prevented built-in file resolution from accessing paths outside the intended directory.
  * Reused verified signed manifest hashes without unnecessary downloads.
  * Treated invalid built-in paths as unavailable instead of valid file sources.

* **Tests**
  * Added regression coverage for Brotli entries, checksum validation, signed hashes, and path traversal protection.
  * Improved reliability of app-ready notification timing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->