### PR TITLE
fix(ci): restore SonarCloud Security Rating on New Code to A

### DIFF
--- a/.github/scripts/backport-lts.sh
+++ b/.github/scripts/backport-lts.sh
@@ -62,12 +62,12 @@ fi
 node "$RESTORE" --target "$TARGET" --repo-root "$ROOT" --config "$SCRIPT_STASH/lts-backport.json"
 
 if command -v bun >/dev/null 2>&1; then
-  bun install
+  bun install --ignore-scripts
   bun run prettier -- --write || echo "prettier write failed; lockfile and constraint restore still applied"
   if [ -f example-app/package.json ]; then
     (
       cd example-app
-      bun install
+      bun install --ignore-scripts
       bunx cap sync || echo "cap sync failed; lockfile and constraint restore still applied"
     )
   fi

--- a/.github/workflows/backport-lts.yml
+++ b/.github/workflows/backport-lts.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # tag=v2
       - name: Self-test constraint restore
         run: node .github/scripts/restore-lts-constraints.mjs --self-test
       - name: Configure Git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
       - name: Install npm CLI for staged publishing
-        run: npm install -g npm@^11.15.0
+        run: npm install -g npm@11.15.0 --ignore-scripts
       - name: Stage publish lts-v5 to npm
         if: ${{ startsWith(github.ref, 'refs/tags/5.') }}
         env:

--- a/.github/workflows/pr_beta_publish.yml
+++ b/.github/workflows/pr_beta_publish.yml
@@ -201,7 +201,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install npm CLI for staged publishing
-        run: npm install -g npm@^11.15.0
+        run: npm install -g npm@11.15.0 --ignore-scripts
 
       - name: Stage publish to npm beta
         env:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Remediate all 7 open SonarCloud vulnerabilities in the new-code period that caused the Quality Gate to fail on main (`Security Rating on New Code` = C, required ≥ A).
- Pin `oven-sh/setup-bun` to full commit SHA in `backport-lts.yml`.
- Add `--ignore-scripts` to `bun install` calls in `backport-lts.sh`.
- Pin `npm@11.15.0` (exact version) and add `--ignore-scripts` to global npm installs in `build.yml` and `pr_beta_publish.yml`.

## Why
- SonarCloud Code Analysis failed on main at `bec22c34` after renovate #884 re-triggered analysis: [check run](https://github.com/Cap-go/capacitor-updater/runs/102024663364).
- [Dashboard](https://sonarcloud.io/dashboard?id=Cap-go_capacitor-updater&branch=main) reports **Failed conditions — C Security Rating on New Code**.
- The setup-node bump was not the root cause; the new-code window includes recent CI additions (LTS backport workflow #875) and npm stage publish steps (#865) with unresolved security findings.

### Sonar findings addressed
| File | Rule | Issue |
|------|------|-------|
| `.github/workflows/backport-lts.yml` | `githubactions:S7637` (HIGH) | Action ref `@v2` → full SHA |
| `.github/scripts/backport-lts.sh` | `shell:S6505` (MEDIUM) ×2 | `bun install` missing `--ignore-scripts` |
| `.github/workflows/build.yml` | `githubactions:S6505`, `S8543` (MEDIUM) | Unpinned `npm@^11.15.0` without `--ignore-scripts` |
| `.github/workflows/pr_beta_publish.yml` | `githubactions:S6505`, `S8543` (MEDIUM) | Same as build.yml |

## How
- Followed existing repo pattern from `deploy_example_app.yml` for `setup-bun` SHA pinning (`0c5077e51419868618aeaa5fe8019c62421857d6`, tag v2).
- Applied Sonar-recommended mitigations for package install steps without weakening the Quality Gate.

## Testing
- Changes are CI/workflow-only; no product code modified.
- SonarCloud Code Analysis on this PR should pass once analysis completes.

## Not Tested
- LTS backport workflow end-to-end (requires scheduled/manual trigger on merge).
- npm stage publish flow (only runs on tag/release).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4dcb52d3-e6a6-4c83-9049-d626164a7765?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4dcb52d3-e6a6-4c83-9049-d626164a7765&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-updater/pr/889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791461141&installation_model_id=430928&pr_number=889&repository=Cap-go%2Fcapacitor-updater&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-updater%2Fpull%2F889&signature=801e970797a995b67b4681311bddee355d63adf480ebb4c9e803462114c2685d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-updater/pull/889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

