### PR TITLE
refactor: replace Version/versioncompare with NativeSemver

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,45 +136,23 @@ jobs:
             .maestro-artifacts
           include-hidden-files: true
           if-no-files-found: error
-      - name: Clear partial Maestro web assets artifact before upload retry
-        if: steps.upload_maestro_web_assets_1.outcome == 'failure'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          artifact_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" --paginate -q ".artifacts[] | select(.name==\"maestro-web-assets\") | .id" | head -1)"
-          if [[ -n "$artifact_id" ]]; then
-            gh api --method DELETE "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" || true
-          fi
-          sleep 30
       - name: Upload reusable Maestro web assets (attempt 2)
         if: steps.upload_maestro_web_assets_1.outcome == 'failure'
         id: upload_maestro_web_assets_2
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
-          name: maestro-web-assets
-          overwrite: true
+          name: maestro-web-assets-r2
           path: |
             dist
             .maestro-artifacts
           include-hidden-files: true
           if-no-files-found: error
-      - name: Clear partial Maestro web assets artifact before final upload retry
-        if: steps.upload_maestro_web_assets_1.outcome == 'failure' && steps.upload_maestro_web_assets_2.outcome == 'failure'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          artifact_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" --paginate -q ".artifacts[] | select(.name==\"maestro-web-assets\") | .id" | head -1)"
-          if [[ -n "$artifact_id" ]]; then
-            gh api --method DELETE "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" || true
-          fi
-          sleep 30
       - name: Upload reusable Maestro web assets (attempt 3)
         if: steps.upload_maestro_web_assets_1.outcome == 'failure' && steps.upload_maestro_web_assets_2.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
-          name: maestro-web-assets
-          overwrite: true
+          name: maestro-web-assets-r3
           path: |
             dist
             .maestro-artifacts
@@ -240,14 +218,25 @@ jobs:
         with:
           name: maestro-web-assets
           path: .
-      - name: Wait before final Maestro web assets download
+      - name: Wait before fallback Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         run: sleep 30
-      - name: Download reusable Maestro web assets (attempt 3)
+      - name: Download reusable Maestro web assets (r2 fallback)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        id: download_maestro_web_assets_r2
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: maestro-web-assets
+          name: maestro-web-assets-r2
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        run: sleep 30
+      - name: Download reusable Maestro web assets (r3 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r3
           path: .
       - name: Build Android app
         run: bun scripts/maestro/prepare-android-scenario.mjs "${{ matrix.scenario }}"
@@ -259,42 +248,20 @@ jobs:
           name: maestro-android-app-${{ matrix.scenario }}
           path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
-      - name: Clear partial Android app artifact before upload retry
-        if: steps.upload_android_app_1.outcome == 'failure'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          artifact_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" --paginate -q ".artifacts[] | select(.name==\"maestro-android-app-${{ matrix.scenario }}\") | .id" | head -1)"
-          if [[ -n "$artifact_id" ]]; then
-            gh api --method DELETE "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" || true
-          fi
-          sleep 30
       - name: Upload Android app (attempt 2)
         if: steps.upload_android_app_1.outcome == 'failure'
         id: upload_android_app_2
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
-          name: maestro-android-app-${{ matrix.scenario }}
-          overwrite: true
+          name: maestro-android-app-${{ matrix.scenario }}-r2
           path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
-      - name: Clear partial Android app artifact before final upload retry
-        if: steps.upload_android_app_1.outcome == 'failure' && steps.upload_android_app_2.outcome == 'failure'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          artifact_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" --paginate -q ".artifacts[] | select(.name==\"maestro-android-app-${{ matrix.scenario }}\") | .id" | head -1)"
-          if [[ -n "$artifact_id" ]]; then
-            gh api --method DELETE "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" || true
-          fi
-          sleep 30
       - name: Upload Android app (attempt 3)
         if: steps.upload_android_app_1.outcome == 'failure' && steps.upload_android_app_2.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
-          name: maestro-android-app-${{ matrix.scenario }}
-          overwrite: true
+          name: maestro-android-app-${{ matrix.scenario }}-r3
           path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
 
@@ -338,14 +305,25 @@ jobs:
         with:
           name: maestro-web-assets
           path: .
-      - name: Wait before final Maestro web assets download
+      - name: Wait before fallback Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         run: sleep 30
-      - name: Download reusable Maestro web assets (attempt 3)
+      - name: Download reusable Maestro web assets (r2 fallback)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        id: download_maestro_web_assets_r2
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: maestro-web-assets
+          name: maestro-web-assets-r2
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        run: sleep 30
+      - name: Download reusable Maestro web assets (r3 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r3
           path: .
       - name: Build iOS app
         run: |
@@ -710,14 +688,25 @@ jobs:
         with:
           name: maestro-web-assets
           path: .
-      - name: Wait before final Maestro web assets download
+      - name: Wait before fallback Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         run: sleep 30
-      - name: Download reusable Maestro web assets (attempt 3)
+      - name: Download reusable Maestro web assets (r2 fallback)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        id: download_maestro_web_assets_r2
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: maestro-web-assets
+          name: maestro-web-assets-r2
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        run: sleep 30
+      - name: Download reusable Maestro web assets (r3 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r3
           path: .
       - name: Download Android app (attempt 1)
         id: download_android_app_1
@@ -737,14 +726,25 @@ jobs:
         with:
           name: maestro-android-app-${{ matrix.scenario }}
           path: example-app/android/app/build/outputs/apk/debug
-      - name: Wait before final Android app download
+      - name: Wait before fallback Android app download
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
         run: sleep 30
-      - name: Download Android app (attempt 3)
+      - name: Download Android app (r2 fallback)
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
+        id: download_android_app_r2
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: maestro-android-app-${{ matrix.scenario }}
+          name: maestro-android-app-${{ matrix.scenario }}-r2
+          path: example-app/android/app/build/outputs/apk/debug
+      - name: Wait before final Android app download
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
+        run: sleep 30
+      - name: Download Android app (r3 fallback)
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}-r3
           path: example-app/android/app/build/outputs/apk/debug
       - name: Enable KVM group perms
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,7 +209,7 @@ jobs:
           path: .
       - name: Wait before retrying Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download reusable Maestro web assets (attempt 2)
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
         id: download_maestro_web_assets_2
@@ -220,7 +220,7 @@ jobs:
           path: .
       - name: Wait before fallback Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download reusable Maestro web assets (r2 fallback)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         id: download_maestro_web_assets_r2
@@ -231,7 +231,7 @@ jobs:
           path: .
       - name: Wait before final Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download reusable Maestro web assets (r3 fallback)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
         uses: actions/download-artifact@v8
@@ -296,7 +296,7 @@ jobs:
           path: .
       - name: Wait before retrying Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download reusable Maestro web assets (attempt 2)
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
         id: download_maestro_web_assets_2
@@ -307,7 +307,7 @@ jobs:
           path: .
       - name: Wait before fallback Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download reusable Maestro web assets (r2 fallback)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         id: download_maestro_web_assets_r2
@@ -318,7 +318,7 @@ jobs:
           path: .
       - name: Wait before final Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download reusable Maestro web assets (r3 fallback)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
         uses: actions/download-artifact@v8
@@ -408,15 +408,81 @@ jobs:
         uses: ./.github/actions/setup-maestro
         with:
           maestro-version: ${{ env.MAESTRO_VERSION }}
-      - name: Download reusable Maestro web assets
+      - name: Download reusable Maestro web assets (attempt 1)
+        id: download_maestro_web_assets_1
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets
           path: .
-      - name: Download Android app
+      - name: Wait before retrying Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 2)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        id: download_maestro_web_assets_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before fallback Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (r2 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        id: download_maestro_web_assets_r2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r2
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (r3 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r3
+          path: .
+      - name: Download Android app (attempt 1)
+        id: download_android_app_1
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: maestro-android-app-${{ matrix.scenario }}
+          path: example-app/android/app/build/outputs/apk/debug
+      - name: Wait before retrying Android app download
+        if: steps.download_android_app_1.outcome == 'failure'
+        run: sleep 15
+      - name: Download Android app (attempt 2)
+        if: steps.download_android_app_1.outcome == 'failure'
+        id: download_android_app_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}
+          path: example-app/android/app/build/outputs/apk/debug
+      - name: Wait before fallback Android app download
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
+        run: sleep 15
+      - name: Download Android app (r2 fallback)
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
+        id: download_android_app_r2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}-r2
+          path: example-app/android/app/build/outputs/apk/debug
+      - name: Wait before final Android app download
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
+        run: sleep 15
+      - name: Download Android app (r3 fallback)
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}-r3
           path: example-app/android/app/build/outputs/apk/debug
       - name: Enable KVM group perms
         run: |
@@ -496,10 +562,43 @@ jobs:
         uses: ./.github/actions/setup-maestro
         with:
           maestro-version: ${{ env.MAESTRO_VERSION }}
-      - name: Download reusable Maestro web assets
+      - name: Download reusable Maestro web assets (attempt 1)
+        id: download_maestro_web_assets_1
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets
+          path: .
+      - name: Wait before retrying Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 2)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        id: download_maestro_web_assets_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before fallback Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (r2 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        id: download_maestro_web_assets_r2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r2
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (r3 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r3
           path: .
       - name: Download iOS app
         uses: actions/download-artifact@v8
@@ -562,10 +661,43 @@ jobs:
         uses: ./.github/actions/setup-maestro
         with:
           maestro-version: ${{ env.MAESTRO_VERSION }}
-      - name: Download reusable Maestro web assets
+      - name: Download reusable Maestro web assets (attempt 1)
+        id: download_maestro_web_assets_1
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets
+          path: .
+      - name: Wait before retrying Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 2)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        id: download_maestro_web_assets_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before fallback Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (r2 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        id: download_maestro_web_assets_r2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r2
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (r3 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r3
           path: .
       - name: Download iOS app
         uses: actions/download-artifact@v8
@@ -679,7 +811,7 @@ jobs:
           path: .
       - name: Wait before retrying Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download reusable Maestro web assets (attempt 2)
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
         id: download_maestro_web_assets_2
@@ -690,7 +822,7 @@ jobs:
           path: .
       - name: Wait before fallback Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download reusable Maestro web assets (r2 fallback)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         id: download_maestro_web_assets_r2
@@ -701,7 +833,7 @@ jobs:
           path: .
       - name: Wait before final Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download reusable Maestro web assets (r3 fallback)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
         uses: actions/download-artifact@v8
@@ -717,7 +849,7 @@ jobs:
           path: example-app/android/app/build/outputs/apk/debug
       - name: Wait before retrying Android app download
         if: steps.download_android_app_1.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download Android app (attempt 2)
         if: steps.download_android_app_1.outcome == 'failure'
         id: download_android_app_2
@@ -728,7 +860,7 @@ jobs:
           path: example-app/android/app/build/outputs/apk/debug
       - name: Wait before fallback Android app download
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download Android app (r2 fallback)
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
         id: download_android_app_r2
@@ -739,7 +871,7 @@ jobs:
           path: example-app/android/app/build/outputs/apk/debug
       - name: Wait before final Android app download
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download Android app (r3 fallback)
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
         uses: actions/download-artifact@v8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,7 @@ jobs:
   maestro_web_assets:
     permissions:
       contents: read
+      actions: write
     timeout-minutes: 10
     runs-on: ubuntu-latest
     name: Build Maestro web assets
@@ -135,6 +136,16 @@ jobs:
             .maestro-artifacts
           include-hidden-files: true
           if-no-files-found: error
+      - name: Clear partial Maestro web assets artifact before upload retry
+        if: steps.upload_maestro_web_assets_1.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" --paginate -q ".artifacts[] | select(.name==\"maestro-web-assets\") | .id" | head -1)"
+          if [[ -n "$artifact_id" ]]; then
+            gh api --method DELETE "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" || true
+          fi
+          sleep 30
       - name: Upload reusable Maestro web assets (attempt 2)
         if: steps.upload_maestro_web_assets_1.outcome == 'failure'
         id: upload_maestro_web_assets_2
@@ -148,6 +159,16 @@ jobs:
             .maestro-artifacts
           include-hidden-files: true
           if-no-files-found: error
+      - name: Clear partial Maestro web assets artifact before final upload retry
+        if: steps.upload_maestro_web_assets_1.outcome == 'failure' && steps.upload_maestro_web_assets_2.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" --paginate -q ".artifacts[] | select(.name==\"maestro-web-assets\") | .id" | head -1)"
+          if [[ -n "$artifact_id" ]]; then
+            gh api --method DELETE "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" || true
+          fi
+          sleep 30
       - name: Upload reusable Maestro web assets (attempt 3)
         if: steps.upload_maestro_web_assets_1.outcome == 'failure' && steps.upload_maestro_web_assets_2.outcome == 'failure'
         uses: actions/upload-artifact@v7
@@ -163,6 +184,7 @@ jobs:
   maestro_android_apps:
     permissions:
       contents: read
+      actions: write
     needs: maestro_web_assets
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -209,7 +231,7 @@ jobs:
           path: .
       - name: Wait before retrying Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        run: sleep 15
+        run: sleep 30
       - name: Download reusable Maestro web assets (attempt 2)
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
         id: download_maestro_web_assets_2
@@ -220,7 +242,7 @@ jobs:
           path: .
       - name: Wait before final Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        run: sleep 15
+        run: sleep 30
       - name: Download reusable Maestro web assets (attempt 3)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         uses: actions/download-artifact@v8
@@ -237,6 +259,16 @@ jobs:
           name: maestro-android-app-${{ matrix.scenario }}
           path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
+      - name: Clear partial Android app artifact before upload retry
+        if: steps.upload_android_app_1.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" --paginate -q ".artifacts[] | select(.name==\"maestro-android-app-${{ matrix.scenario }}\") | .id" | head -1)"
+          if [[ -n "$artifact_id" ]]; then
+            gh api --method DELETE "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" || true
+          fi
+          sleep 30
       - name: Upload Android app (attempt 2)
         if: steps.upload_android_app_1.outcome == 'failure'
         id: upload_android_app_2
@@ -247,6 +279,16 @@ jobs:
           overwrite: true
           path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
+      - name: Clear partial Android app artifact before final upload retry
+        if: steps.upload_android_app_1.outcome == 'failure' && steps.upload_android_app_2.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" --paginate -q ".artifacts[] | select(.name==\"maestro-android-app-${{ matrix.scenario }}\") | .id" | head -1)"
+          if [[ -n "$artifact_id" ]]; then
+            gh api --method DELETE "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" || true
+          fi
+          sleep 30
       - name: Upload Android app (attempt 3)
         if: steps.upload_android_app_1.outcome == 'failure' && steps.upload_android_app_2.outcome == 'failure'
         uses: actions/upload-artifact@v7
@@ -259,6 +301,7 @@ jobs:
   maestro_ios_apps:
     permissions:
       contents: read
+      actions: write
     needs: maestro_web_assets
     timeout-minutes: 10
     runs-on: macOS-latest
@@ -286,7 +329,7 @@ jobs:
           path: .
       - name: Wait before retrying Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        run: sleep 15
+        run: sleep 30
       - name: Download reusable Maestro web assets (attempt 2)
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
         id: download_maestro_web_assets_2
@@ -297,7 +340,7 @@ jobs:
           path: .
       - name: Wait before final Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        run: sleep 15
+        run: sleep 30
       - name: Download reusable Maestro web assets (attempt 3)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         uses: actions/download-artifact@v8
@@ -347,6 +390,7 @@ jobs:
   maestro_android_example_app:
     permissions:
       contents: read
+      actions: write
     needs:
       - maestro_web_assets
       - maestro_android_apps
@@ -440,6 +484,7 @@ jobs:
   maestro_ios_example_app:
     permissions:
       contents: read
+      actions: write
     needs:
       - maestro_web_assets
       - maestro_ios_apps
@@ -505,6 +550,7 @@ jobs:
   maestro_ios_live_update:
     permissions:
       contents: read
+      actions: write
     needs:
       - maestro_web_assets
       - maestro_ios_apps
@@ -602,6 +648,7 @@ jobs:
   maestro_android_scenarios:
     permissions:
       contents: read
+      actions: read
     needs:
       - maestro_web_assets
       - maestro_android_apps
@@ -654,7 +701,7 @@ jobs:
           path: .
       - name: Wait before retrying Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        run: sleep 15
+        run: sleep 30
       - name: Download reusable Maestro web assets (attempt 2)
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
         id: download_maestro_web_assets_2
@@ -665,7 +712,7 @@ jobs:
           path: .
       - name: Wait before final Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        run: sleep 15
+        run: sleep 30
       - name: Download reusable Maestro web assets (attempt 3)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         uses: actions/download-artifact@v8
@@ -681,7 +728,7 @@ jobs:
           path: example-app/android/app/build/outputs/apk/debug
       - name: Wait before retrying Android app download
         if: steps.download_android_app_1.outcome == 'failure'
-        run: sleep 15
+        run: sleep 30
       - name: Download Android app (attempt 2)
         if: steps.download_android_app_1.outcome == 'failure'
         id: download_android_app_2
@@ -692,7 +739,7 @@ jobs:
           path: example-app/android/app/build/outputs/apk/debug
       - name: Wait before final Android app download
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
-        run: sleep 15
+        run: sleep 30
       - name: Download Android app (attempt 3)
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
         uses: actions/download-artifact@v8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,7 @@ jobs:
   maestro_web_assets:
     permissions:
       contents: read
+      actions: write
     timeout-minutes: 10
     runs-on: ubuntu-latest
     name: Build Maestro web assets
@@ -137,6 +138,7 @@ jobs:
   maestro_android_apps:
     permissions:
       contents: read
+      actions: write
     needs: maestro_web_assets
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -191,6 +193,7 @@ jobs:
   maestro_ios_apps:
     permissions:
       contents: read
+      actions: write
     needs: maestro_web_assets
     timeout-minutes: 10
     runs-on: macOS-latest
@@ -257,6 +260,7 @@ jobs:
   maestro_android_example_app:
     permissions:
       contents: read
+      actions: write
     needs:
       - maestro_web_assets
       - maestro_android_apps
@@ -350,6 +354,7 @@ jobs:
   maestro_ios_example_app:
     permissions:
       contents: read
+      actions: write
     needs:
       - maestro_web_assets
       - maestro_ios_apps
@@ -415,6 +420,7 @@ jobs:
   maestro_ios_live_update:
     permissions:
       contents: read
+      actions: write
     needs:
       - maestro_web_assets
       - maestro_ios_apps
@@ -512,6 +518,7 @@ jobs:
   maestro_android_scenarios:
     permissions:
       contents: read
+      actions: read
     needs:
       - maestro_web_assets
       - maestro_android_apps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,6 @@ jobs:
   maestro_web_assets:
     permissions:
       contents: read
-      actions: write
     timeout-minutes: 10
     runs-on: ubuntu-latest
     name: Build Maestro web assets
@@ -143,6 +142,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: maestro-web-assets
+          overwrite: true
           path: |
             dist
             .maestro-artifacts
@@ -153,6 +153,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: maestro-web-assets
+          overwrite: true
           path: |
             dist
             .maestro-artifacts
@@ -162,7 +163,6 @@ jobs:
   maestro_android_apps:
     permissions:
       contents: read
-      actions: write
     needs: maestro_web_assets
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -200,7 +200,29 @@ jobs:
           distribution: 'zulu'
           java-version: '21'
           cache: gradle
-      - name: Download reusable Maestro web assets
+      - name: Download reusable Maestro web assets (attempt 1)
+        id: download_maestro_web_assets_1
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before retrying Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 2)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        id: download_maestro_web_assets_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 3)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets
@@ -222,6 +244,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: maestro-android-app-${{ matrix.scenario }}
+          overwrite: true
           path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
       - name: Upload Android app (attempt 3)
@@ -229,13 +252,13 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: maestro-android-app-${{ matrix.scenario }}
+          overwrite: true
           path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
 
   maestro_ios_apps:
     permissions:
       contents: read
-      actions: write
     needs: maestro_web_assets
     timeout-minutes: 10
     runs-on: macOS-latest
@@ -254,7 +277,29 @@ jobs:
             node_modules
             example-app/node_modules
           install-example: 'true'
-      - name: Download reusable Maestro web assets
+      - name: Download reusable Maestro web assets (attempt 1)
+        id: download_maestro_web_assets_1
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before retrying Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 2)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        id: download_maestro_web_assets_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 3)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets
@@ -302,7 +347,6 @@ jobs:
   maestro_android_example_app:
     permissions:
       contents: read
-      actions: write
     needs:
       - maestro_web_assets
       - maestro_android_apps
@@ -396,7 +440,6 @@ jobs:
   maestro_ios_example_app:
     permissions:
       contents: read
-      actions: write
     needs:
       - maestro_web_assets
       - maestro_ios_apps
@@ -462,7 +505,6 @@ jobs:
   maestro_ios_live_update:
     permissions:
       contents: read
-      actions: write
     needs:
       - maestro_web_assets
       - maestro_ios_apps
@@ -560,7 +602,6 @@ jobs:
   maestro_android_scenarios:
     permissions:
       contents: read
-      actions: write
     needs:
       - maestro_web_assets
       - maestro_android_apps
@@ -611,6 +652,9 @@ jobs:
         with:
           name: maestro-web-assets
           path: .
+      - name: Wait before retrying Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        run: sleep 15
       - name: Download reusable Maestro web assets (attempt 2)
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
         id: download_maestro_web_assets_2
@@ -619,6 +663,9 @@ jobs:
         with:
           name: maestro-web-assets
           path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        run: sleep 15
       - name: Download reusable Maestro web assets (attempt 3)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         uses: actions/download-artifact@v8
@@ -632,6 +679,9 @@ jobs:
         with:
           name: maestro-android-app-${{ matrix.scenario }}
           path: example-app/android/app/build/outputs/apk/debug
+      - name: Wait before retrying Android app download
+        if: steps.download_android_app_1.outcome == 'failure'
+        run: sleep 15
       - name: Download Android app (attempt 2)
         if: steps.download_android_app_1.outcome == 'failure'
         id: download_android_app_2
@@ -640,6 +690,9 @@ jobs:
         with:
           name: maestro-android-app-${{ matrix.scenario }}
           path: example-app/android/app/build/outputs/apk/debug
+      - name: Wait before final Android app download
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
+        run: sleep 15
       - name: Download Android app (attempt 3)
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
         uses: actions/download-artifact@v8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,11 +229,22 @@ jobs:
         with:
           name: maestro-web-assets-r2
           path: .
-      - name: Wait before final Maestro web assets download
+      - name: Wait before retrying Maestro web assets r2 download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
         run: sleep 15
-      - name: Download reusable Maestro web assets (r3 fallback)
+      - name: Download reusable Maestro web assets (r2 retry)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        id: download_maestro_web_assets_r2b
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r2
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure' && steps.download_maestro_web_assets_r2b.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (r3 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure' && steps.download_maestro_web_assets_r2b.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets-r3
@@ -316,11 +327,22 @@ jobs:
         with:
           name: maestro-web-assets-r2
           path: .
-      - name: Wait before final Maestro web assets download
+      - name: Wait before retrying Maestro web assets r2 download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
         run: sleep 15
-      - name: Download reusable Maestro web assets (r3 fallback)
+      - name: Download reusable Maestro web assets (r2 retry)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        id: download_maestro_web_assets_r2b
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r2
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure' && steps.download_maestro_web_assets_r2b.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (r3 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure' && steps.download_maestro_web_assets_r2b.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets-r3
@@ -437,11 +459,22 @@ jobs:
         with:
           name: maestro-web-assets-r2
           path: .
-      - name: Wait before final Maestro web assets download
+      - name: Wait before retrying Maestro web assets r2 download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
         run: sleep 15
-      - name: Download reusable Maestro web assets (r3 fallback)
+      - name: Download reusable Maestro web assets (r2 retry)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        id: download_maestro_web_assets_r2b
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r2
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure' && steps.download_maestro_web_assets_r2b.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (r3 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure' && steps.download_maestro_web_assets_r2b.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets-r3
@@ -475,11 +508,22 @@ jobs:
         with:
           name: maestro-android-app-${{ matrix.scenario }}-r2
           path: example-app/android/app/build/outputs/apk/debug
-      - name: Wait before final Android app download
+      - name: Wait before retrying Android app r2 download
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
         run: sleep 15
-      - name: Download Android app (r3 fallback)
+      - name: Download Android app (r2 retry)
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
+        id: download_android_app_r2b
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}-r2
+          path: example-app/android/app/build/outputs/apk/debug
+      - name: Wait before final Android app download
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure' && steps.download_android_app_r2b.outcome == 'failure'
+        run: sleep 15
+      - name: Download Android app (r3 fallback)
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure' && steps.download_android_app_r2b.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: maestro-android-app-${{ matrix.scenario }}-r3
@@ -591,11 +635,22 @@ jobs:
         with:
           name: maestro-web-assets-r2
           path: .
-      - name: Wait before final Maestro web assets download
+      - name: Wait before retrying Maestro web assets r2 download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
         run: sleep 15
-      - name: Download reusable Maestro web assets (r3 fallback)
+      - name: Download reusable Maestro web assets (r2 retry)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        id: download_maestro_web_assets_r2b
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r2
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure' && steps.download_maestro_web_assets_r2b.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (r3 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure' && steps.download_maestro_web_assets_r2b.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets-r3
@@ -690,11 +745,22 @@ jobs:
         with:
           name: maestro-web-assets-r2
           path: .
-      - name: Wait before final Maestro web assets download
+      - name: Wait before retrying Maestro web assets r2 download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
         run: sleep 15
-      - name: Download reusable Maestro web assets (r3 fallback)
+      - name: Download reusable Maestro web assets (r2 retry)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        id: download_maestro_web_assets_r2b
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r2
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure' && steps.download_maestro_web_assets_r2b.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (r3 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure' && steps.download_maestro_web_assets_r2b.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets-r3
@@ -831,11 +897,22 @@ jobs:
         with:
           name: maestro-web-assets-r2
           path: .
-      - name: Wait before final Maestro web assets download
+      - name: Wait before retrying Maestro web assets r2 download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
         run: sleep 15
-      - name: Download reusable Maestro web assets (r3 fallback)
+      - name: Download reusable Maestro web assets (r2 retry)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        id: download_maestro_web_assets_r2b
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r2
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure' && steps.download_maestro_web_assets_r2b.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (r3 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure' && steps.download_maestro_web_assets_r2b.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets-r3
@@ -869,11 +946,22 @@ jobs:
         with:
           name: maestro-android-app-${{ matrix.scenario }}-r2
           path: example-app/android/app/build/outputs/apk/debug
-      - name: Wait before final Android app download
+      - name: Wait before retrying Android app r2 download
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
         run: sleep 15
-      - name: Download Android app (r3 fallback)
+      - name: Download Android app (r2 retry)
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
+        id: download_android_app_r2b
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}-r2
+          path: example-app/android/app/build/outputs/apk/debug
+      - name: Wait before final Android app download
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure' && steps.download_android_app_r2b.outcome == 'failure'
+        run: sleep 15
+      - name: Download Android app (r3 fallback)
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure' && steps.download_android_app_r2b.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: maestro-android-app-${{ matrix.scenario }}-r3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,31 @@ jobs:
           install-example: 'true'
       - name: Build reusable Maestro web assets
         run: bun scripts/maestro/build-bundles.mjs all
-      - name: Upload reusable Maestro web assets
+      - name: Upload reusable Maestro web assets (attempt 1)
+        id: upload_maestro_web_assets_1
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: maestro-web-assets
+          path: |
+            dist
+            .maestro-artifacts
+          include-hidden-files: true
+          if-no-files-found: error
+      - name: Upload reusable Maestro web assets (attempt 2)
+        if: steps.upload_maestro_web_assets_1.outcome == 'failure'
+        id: upload_maestro_web_assets_2
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: maestro-web-assets
+          path: |
+            dist
+            .maestro-artifacts
+          include-hidden-files: true
+          if-no-files-found: error
+      - name: Upload reusable Maestro web assets (attempt 3)
+        if: steps.upload_maestro_web_assets_1.outcome == 'failure' && steps.upload_maestro_web_assets_2.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
           name: maestro-web-assets
@@ -183,7 +207,25 @@ jobs:
           path: .
       - name: Build Android app
         run: bun scripts/maestro/prepare-android-scenario.mjs "${{ matrix.scenario }}"
-      - name: Upload Android app
+      - name: Upload Android app (attempt 1)
+        id: upload_android_app_1
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}
+          path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
+      - name: Upload Android app (attempt 2)
+        if: steps.upload_android_app_1.outcome == 'failure'
+        id: upload_android_app_2
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}
+          path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
+      - name: Upload Android app (attempt 3)
+        if: steps.upload_android_app_1.outcome == 'failure' && steps.upload_android_app_2.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
           name: maestro-android-app-${{ matrix.scenario }}
@@ -518,7 +560,7 @@ jobs:
   maestro_android_scenarios:
     permissions:
       contents: read
-      actions: read
+      actions: write
     needs:
       - maestro_web_assets
       - maestro_android_apps
@@ -562,12 +604,44 @@ jobs:
         uses: ./.github/actions/setup-maestro
         with:
           maestro-version: ${{ env.MAESTRO_VERSION }}
-      - name: Download reusable Maestro web assets
+      - name: Download reusable Maestro web assets (attempt 1)
+        id: download_maestro_web_assets_1
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets
           path: .
-      - name: Download Android app
+      - name: Download reusable Maestro web assets (attempt 2)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        id: download_maestro_web_assets_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Download reusable Maestro web assets (attempt 3)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Download Android app (attempt 1)
+        id: download_android_app_1
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}
+          path: example-app/android/app/build/outputs/apk/debug
+      - name: Download Android app (attempt 2)
+        if: steps.download_android_app_1.outcome == 'failure'
+        id: download_android_app_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}
+          path: example-app/android/app/build/outputs/apk/debug
+      - name: Download Android app (attempt 3)
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: maestro-android-app-${{ matrix.scenario }}

--- a/CapgoCapacitorUpdater.podspec
+++ b/CapgoCapacitorUpdater.podspec
@@ -15,6 +15,5 @@ Pod::Spec.new do |s|
   s.dependency 'Capacitor'
   s.dependency 'ZIPFoundation', '~> 0.9'
   s.dependency 'Alamofire', '5.10.2'
-  s.dependency 'Version', '0.8.0'
   s.swift_version = '5.1'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
         .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.12.0")),
-        .package(url: "https://github.com/weichsel/ZIPFoundation.git", from: "0.9.20"),
-        .package(url: "https://github.com/mrackwitz/Version.git", exact: "0.8.0")
+        .package(url: "https://github.com/weichsel/ZIPFoundation.git", from: "0.9.20")
     ],
     targets: [
         .target(
@@ -22,15 +21,13 @@ let package = Package(
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
                 .product(name: "ZIPFoundation", package: "ZIPFoundation"),
-                .product(name: "Alamofire", package: "Alamofire"),
-                .product(name: "Version", package: "Version")
+                .product(name: "Alamofire", package: "Alamofire")
             ],
             path: "ios/Sources/CapacitorUpdaterPlugin"),
         .testTarget(
             name: "CapacitorUpdaterPluginTests",
             dependencies: [
                 "CapacitorUpdaterPlugin",
-                .product(name: "Version", package: "Version"),
                 .product(name: "ZIPFoundation", package: "ZIPFoundation")
             ],
             path: "ios/Tests/CapacitorUpdaterPluginTests")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,7 +58,6 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
-    implementation 'io.github.g00fy2:versioncompare:1.5.0'
     // Play Core library for in-app updates
     implementation 'com.google.android.play:app-update:2.1.0'
     implementation 'com.google.android.play:app-update-ktx:2.1.0'

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -48,7 +48,7 @@ import com.google.android.play.core.install.InstallStateUpdatedListener;
 import com.google.android.play.core.install.model.AppUpdateType;
 import com.google.android.play.core.install.model.InstallStatus;
 import com.google.android.play.core.install.model.UpdateAvailability;
-import io.github.g00fy2.versioncompare.Version;
+import ee.forgr.capacitor_updater.NativeSemver;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -164,7 +164,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
     private Boolean autoUpdate = false;
     private String autoUpdateMode = AUTO_UPDATE_MODE_OFF;
     private String updateUrl = "";
-    private Version currentVersionNative;
+    private NativeSemver currentVersionNative;
     private String currentBuildVersion;
     private Thread backgroundTask;
     private Boolean taskRunning = false;
@@ -727,7 +727,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
             this.implementation.pluginVersion = this.pluginVersion;
             this.implementation.versionCode = this.getVersionCode(pInfo);
             // Removed unused OkHttpClient creation - using shared client in DownloadService instead
-            this.currentVersionNative = new Version(this.getConfig().getString("version", pInfo.versionName));
+            this.currentVersionNative = new NativeSemver(this.getConfig().getString("version", pInfo.versionName));
             this.currentBuildVersion = this.getVersionCode(pInfo);
             this.delayUpdateUtils = new DelayUpdateUtils(this.prefs, this.editor, this.currentVersionNative, logger);
         } catch (final PackageManager.NameNotFoundException e) {

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -727,7 +727,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
             this.implementation.pluginVersion = this.pluginVersion;
             this.implementation.versionCode = this.getVersionCode(pInfo);
             // Removed unused OkHttpClient creation - using shared client in DownloadService instead
-            this.currentVersionNative = new NativeSemver(this.getConfig().getString("version", pInfo.versionName));
+            this.currentVersionNative = NativeSemver.parseOrDefault(this.getConfig().getString("version", pInfo.versionName), "0.0.0");
             this.currentBuildVersion = this.getVersionCode(pInfo);
             this.delayUpdateUtils = new DelayUpdateUtils(this.prefs, this.editor, this.currentVersionNative, logger);
         } catch (final PackageManager.NameNotFoundException e) {

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -858,7 +858,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
             }
         }
         logger.info("init for device " + this.implementation.deviceID);
-        logger.info("version native " + this.currentVersionNative.getOriginalString());
+        logger.info("version native " + this.currentVersionNative);
         this.reportAppLaunchStart();
         this.autoDeleteFailed = this.getConfig().getBoolean("autoDeleteFailed", true);
         this.autoDeletePrevious = this.getConfig().getBoolean("autoDeletePrevious", true);

--- a/android/src/main/java/ee/forgr/capacitor_updater/DelayUpdateUtils.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DelayUpdateUtils.java
@@ -130,7 +130,7 @@ public class DelayUpdateUtils {
                     if (!"".equals(value)) {
                         try {
                             final NativeSemver versionLimit = new NativeSemver(value);
-                            if (this.currentVersionNative.isAtLeast(versionLimit)) {
+                            if (this.currentVersionNative.compareTo(versionLimit) >= 0) {
                                 logger.info(
                                     "Native version delay (value: " + value + ") condition removed due to above limit at index " + index
                                 );

--- a/android/src/main/java/ee/forgr/capacitor_updater/DelayUpdateUtils.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DelayUpdateUtils.java
@@ -1,7 +1,6 @@
 package ee.forgr.capacitor_updater;
 
 import android.content.SharedPreferences;
-import io.github.g00fy2.versioncompare.Version;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -21,9 +20,9 @@ public class DelayUpdateUtils {
 
     private final SharedPreferences prefs;
     private final SharedPreferences.Editor editor;
-    private final Version currentVersionNative;
+    private final NativeSemver currentVersionNative;
 
-    public DelayUpdateUtils(SharedPreferences prefs, SharedPreferences.Editor editor, Version currentVersionNative, Logger logger) {
+    public DelayUpdateUtils(SharedPreferences prefs, SharedPreferences.Editor editor, NativeSemver currentVersionNative, Logger logger) {
         this.prefs = prefs;
         this.editor = editor;
         this.currentVersionNative = currentVersionNative;
@@ -130,7 +129,7 @@ public class DelayUpdateUtils {
                 case DelayUntilNext.nativeVersion:
                     if (!"".equals(value)) {
                         try {
-                            final Version versionLimit = new Version(value);
+                            final NativeSemver versionLimit = new NativeSemver(value);
                             if (this.currentVersionNative.isAtLeast(versionLimit)) {
                                 logger.info(
                                     "Native version delay (value: " + value + ") condition removed due to above limit at index " + index

--- a/android/src/main/java/ee/forgr/capacitor_updater/NativeSemver.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/NativeSemver.java
@@ -12,22 +12,59 @@ public final class NativeSemver implements Comparable<NativeSemver> {
 
     private final String original;
     private final List<Long> numericParts;
+    private final String prerelease;
+
+    public static NativeSemver parseOrDefault(final String version, final String fallback) {
+        try {
+            if (version == null || version.isEmpty()) {
+                return new NativeSemver(fallback);
+            }
+            return new NativeSemver(version);
+        } catch (final IllegalArgumentException ignored) {
+            return new NativeSemver(fallback);
+        }
+    }
 
     public NativeSemver(final String version) {
         if (version == null || version.isEmpty()) {
             throw new IllegalArgumentException("Version must not be empty");
         }
         this.original = version;
-        this.numericParts = parseNumericParts(version);
+        final CoreParts core = splitCoreAndPrerelease(version);
+        this.numericParts = parseNumericParts(core.core);
+        this.prerelease = core.prerelease;
         if (numericParts.isEmpty()) {
             throw new IllegalArgumentException("Version has no numeric components: " + version);
         }
     }
 
-    private static List<Long> parseNumericParts(final String version) {
+    private static final class CoreParts {
+
+        private final String core;
+        private final String prerelease;
+
+        private CoreParts(final String core, final String prerelease) {
+            this.core = core;
+            this.prerelease = prerelease;
+        }
+    }
+
+    private static CoreParts splitCoreAndPrerelease(final String version) {
+        String working = version;
+        final int plusIdx = working.indexOf('+');
+        if (plusIdx >= 0) {
+            working = working.substring(0, plusIdx);
+        }
+        final int dashIdx = working.indexOf('-');
+        if (dashIdx >= 0) {
+            return new CoreParts(working.substring(0, dashIdx), working.substring(dashIdx + 1));
+        }
+        return new CoreParts(working, null);
+    }
+
+    private static List<Long> parseNumericParts(final String core) {
         final List<Long> parts = new ArrayList<>();
-        final String[] segments = version.split("[.\\-+_]");
-        for (final String segment : segments) {
+        for (final String segment : core.split("\\.")) {
             if (segment.isEmpty()) {
                 continue;
             }
@@ -36,10 +73,21 @@ public final class NativeSemver implements Comparable<NativeSemver> {
                 end++;
             }
             if (end > 0) {
-                parts.add(Long.parseLong(segment.substring(0, end)));
+                parts.add(parseNumericComponent(segment.substring(0, end)));
             }
         }
         return parts;
+    }
+
+    private static long parseNumericComponent(final String digits) {
+        if (digits.length() > 19) {
+            return Long.MAX_VALUE;
+        }
+        try {
+            return Long.parseLong(digits);
+        } catch (final NumberFormatException ignored) {
+            return Long.MAX_VALUE;
+        }
     }
 
     public boolean isAtLeast(final String version) {
@@ -67,7 +115,16 @@ public final class NativeSemver implements Comparable<NativeSemver> {
                 return 1;
             }
         }
-        return 0;
+        if (prerelease == null && other.prerelease == null) {
+            return 0;
+        }
+        if (prerelease == null) {
+            return 1;
+        }
+        if (other.prerelease == null) {
+            return -1;
+        }
+        return prerelease.compareTo(other.prerelease);
     }
 
     @Override
@@ -83,11 +140,11 @@ public final class NativeSemver implements Comparable<NativeSemver> {
         if (!(other instanceof NativeSemver)) {
             return false;
         }
-        return compareTo((NativeSemver) other) == 0 && Objects.equals(original, ((NativeSemver) other).original);
+        return compareTo((NativeSemver) other) == 0;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(original, numericParts);
+        return Objects.hash(numericParts, prerelease);
     }
 }

--- a/android/src/main/java/ee/forgr/capacitor_updater/NativeSemver.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/NativeSemver.java
@@ -69,7 +69,7 @@ public final class NativeSemver implements Comparable<NativeSemver> {
                 continue;
             }
             int end = 0;
-            while (end < segment.length() && Character.isDigit(segment.charAt(end))) {
+            while (end < segment.length() && isAsciiDigit(segment.charAt(end))) {
                 end++;
             }
             if (end > 0) {
@@ -170,12 +170,17 @@ public final class NativeSemver implements Comparable<NativeSemver> {
         return left.compareTo(right);
     }
 
+    /** SemVer numeric identifiers are ASCII digits only (`0`–`9`), not Unicode Nd/No. */
+    private static boolean isAsciiDigit(final char c) {
+        return c >= '0' && c <= '9';
+    }
+
     private static boolean isNumericIdentifier(final String value) {
         if (value.isEmpty()) {
             return false;
         }
         for (int i = 0; i < value.length(); i++) {
-            if (!Character.isDigit(value.charAt(i))) {
+            if (!isAsciiDigit(value.charAt(i))) {
                 return false;
             }
         }

--- a/android/src/main/java/ee/forgr/capacitor_updater/NativeSemver.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/NativeSemver.java
@@ -64,7 +64,7 @@ public final class NativeSemver implements Comparable<NativeSemver> {
 
     private static List<Long> parseNumericParts(final String core) {
         final List<Long> parts = new ArrayList<>();
-        for (final String segment : core.split("\\.")) {
+        for (final String segment : core.split("[._]")) {
             if (segment.isEmpty()) {
                 continue;
             }
@@ -124,7 +124,70 @@ public final class NativeSemver implements Comparable<NativeSemver> {
         if (other.prerelease == null) {
             return -1;
         }
-        return prerelease.compareTo(other.prerelease);
+        return comparePrerelease(prerelease, other.prerelease);
+    }
+
+    private static int comparePrerelease(final String left, final String right) {
+        final String[] leftIds = left.split("\\.");
+        final String[] rightIds = right.split("\\.");
+        final int max = Math.max(leftIds.length, rightIds.length);
+        for (int i = 0; i < max; i++) {
+            if (i >= leftIds.length) {
+                return -1;
+            }
+            if (i >= rightIds.length) {
+                return 1;
+            }
+            final int cmp = comparePrereleaseIdentifier(leftIds[i], rightIds[i]);
+            if (cmp != 0) {
+                return cmp;
+            }
+        }
+        return 0;
+    }
+
+    private static int comparePrereleaseIdentifier(final String left, final String right) {
+        final boolean leftNumeric = isNumericIdentifier(left);
+        final boolean rightNumeric = isNumericIdentifier(right);
+        if (leftNumeric && rightNumeric) {
+            // SemVer: compare numeric identifiers by digit magnitude (length, then lexical).
+            final int lengthCmp = Integer.compare(stripLeadingZeros(left).length(), stripLeadingZeros(right).length());
+            if (lengthCmp != 0) {
+                return lengthCmp;
+            }
+            final int digitCmp = stripLeadingZeros(left).compareTo(stripLeadingZeros(right));
+            if (digitCmp != 0) {
+                return digitCmp;
+            }
+            return 0;
+        }
+        if (leftNumeric) {
+            return -1;
+        }
+        if (rightNumeric) {
+            return 1;
+        }
+        return left.compareTo(right);
+    }
+
+    private static boolean isNumericIdentifier(final String value) {
+        if (value.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            if (!Character.isDigit(value.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static String stripLeadingZeros(final String digits) {
+        int i = 0;
+        while (i < digits.length() - 1 && digits.charAt(i) == '0') {
+            i++;
+        }
+        return digits.substring(i);
     }
 
     @Override
@@ -145,6 +208,10 @@ public final class NativeSemver implements Comparable<NativeSemver> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(numericParts, prerelease);
+        final List<Long> normalized = new ArrayList<>(numericParts);
+        while (normalized.size() > 1 && normalized.get(normalized.size() - 1) == 0L) {
+            normalized.remove(normalized.size() - 1);
+        }
+        return Objects.hash(normalized, prerelease);
     }
 }

--- a/android/src/main/java/ee/forgr/capacitor_updater/NativeSemver.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/NativeSemver.java
@@ -1,0 +1,93 @@
+package ee.forgr.capacitor_updater;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Lightweight semver-style comparator for native app version strings.
+ * Replaces the third-party versioncompare dependency for delay-update checks.
+ */
+public final class NativeSemver implements Comparable<NativeSemver> {
+
+    private final String original;
+    private final List<Long> numericParts;
+
+    public NativeSemver(final String version) {
+        if (version == null || version.isEmpty()) {
+            throw new IllegalArgumentException("Version must not be empty");
+        }
+        this.original = version;
+        this.numericParts = parseNumericParts(version);
+        if (numericParts.isEmpty()) {
+            throw new IllegalArgumentException("Version has no numeric components: " + version);
+        }
+    }
+
+    private static List<Long> parseNumericParts(final String version) {
+        final List<Long> parts = new ArrayList<>();
+        final String[] segments = version.split("[.\\-+_]");
+        for (final String segment : segments) {
+            if (segment.isEmpty()) {
+                continue;
+            }
+            int end = 0;
+            while (end < segment.length() && Character.isDigit(segment.charAt(end))) {
+                end++;
+            }
+            if (end > 0) {
+                parts.add(Long.parseLong(segment.substring(0, end)));
+            }
+        }
+        return parts;
+    }
+
+    public boolean isAtLeast(final String version) {
+        return compareTo(new NativeSemver(version)) >= 0;
+    }
+
+    public boolean isLowerThan(final NativeSemver other) {
+        return compareTo(other) < 0;
+    }
+
+    public boolean isEqual(final NativeSemver other) {
+        return compareTo(other) == 0;
+    }
+
+    @Override
+    public int compareTo(final NativeSemver other) {
+        final int max = Math.max(numericParts.size(), other.numericParts.size());
+        for (int i = 0; i < max; i++) {
+            final long left = i < numericParts.size() ? numericParts.get(i) : 0L;
+            final long right = i < other.numericParts.size() ? other.numericParts.get(i) : 0L;
+            if (left < right) {
+                return -1;
+            }
+            if (left > right) {
+                return 1;
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    public String toString() {
+        return original;
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof NativeSemver)) {
+            return false;
+        }
+        return compareTo((NativeSemver) other) == 0 && Objects.equals(original, ((NativeSemver) other).original);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(original, numericParts);
+    }
+}

--- a/android/src/main/java/ee/forgr/capacitor_updater/NativeSemver.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/NativeSemver.java
@@ -1,5 +1,6 @@
 package ee.forgr.capacitor_updater;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -10,8 +11,10 @@ import java.util.Objects;
  */
 public final class NativeSemver implements Comparable<NativeSemver> {
 
+    private static final BigInteger UINT64_MAX = new BigInteger("18446744073709551615");
+
     private final String original;
-    private final List<Long> numericParts;
+    private final List<BigInteger> numericParts;
     private final String prerelease;
 
     public static NativeSemver parseOrDefault(final String version, final String fallback) {
@@ -57,13 +60,14 @@ public final class NativeSemver implements Comparable<NativeSemver> {
         }
         final int dashIdx = working.indexOf('-');
         if (dashIdx >= 0) {
-            return new CoreParts(working.substring(0, dashIdx), working.substring(dashIdx + 1));
+            final String prereleasePart = working.substring(dashIdx + 1);
+            return new CoreParts(working.substring(0, dashIdx), prereleasePart.isEmpty() ? null : prereleasePart);
         }
         return new CoreParts(working, null);
     }
 
-    private static List<Long> parseNumericParts(final String core) {
-        final List<Long> parts = new ArrayList<>();
+    private static List<BigInteger> parseNumericParts(final String core) {
+        final List<BigInteger> parts = new ArrayList<>();
         for (final String segment : core.split("[._]")) {
             if (segment.isEmpty()) {
                 continue;
@@ -79,14 +83,15 @@ public final class NativeSemver implements Comparable<NativeSemver> {
         return parts;
     }
 
-    private static long parseNumericComponent(final String digits) {
-        if (digits.length() > 19) {
-            return Long.MAX_VALUE;
+    private static BigInteger parseNumericComponent(final String digits) {
+        if (digits.length() > 20) {
+            return UINT64_MAX;
         }
         try {
-            return Long.parseLong(digits);
+            final BigInteger value = new BigInteger(digits);
+            return value.compareTo(UINT64_MAX) > 0 ? UINT64_MAX : value;
         } catch (final NumberFormatException ignored) {
-            return Long.MAX_VALUE;
+            return UINT64_MAX;
         }
     }
 
@@ -106,13 +111,11 @@ public final class NativeSemver implements Comparable<NativeSemver> {
     public int compareTo(final NativeSemver other) {
         final int max = Math.max(numericParts.size(), other.numericParts.size());
         for (int i = 0; i < max; i++) {
-            final long left = i < numericParts.size() ? numericParts.get(i) : 0L;
-            final long right = i < other.numericParts.size() ? other.numericParts.get(i) : 0L;
-            if (left < right) {
-                return -1;
-            }
-            if (left > right) {
-                return 1;
+            final BigInteger left = i < numericParts.size() ? numericParts.get(i) : BigInteger.ZERO;
+            final BigInteger right = i < other.numericParts.size() ? other.numericParts.get(i) : BigInteger.ZERO;
+            final int cmp = left.compareTo(right);
+            if (cmp != 0) {
+                return cmp;
             }
         }
         if (prerelease == null && other.prerelease == null) {
@@ -213,8 +216,8 @@ public final class NativeSemver implements Comparable<NativeSemver> {
 
     @Override
     public int hashCode() {
-        final List<Long> normalized = new ArrayList<>(numericParts);
-        while (normalized.size() > 1 && normalized.get(normalized.size() - 1) == 0L) {
+        final List<BigInteger> normalized = new ArrayList<>(numericParts);
+        while (normalized.size() > 1 && normalized.get(normalized.size() - 1).equals(BigInteger.ZERO)) {
             normalized.remove(normalized.size() - 1);
         }
         return Objects.hash(normalized, prerelease);

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -17,7 +17,7 @@ import com.getcapacitor.JSObject;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginConfig;
 import com.getcapacitor.PluginHandle;
-import io.github.g00fy2.versioncompare.Version;
+import ee.forgr.capacitor_updater.NativeSemver;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -1360,10 +1360,10 @@ public class CapacitorUpdaterUnitTest {
 
     @Test
     public void testVersionComparison() {
-        Version version1 = new Version("1.0.0");
-        Version version2 = new Version("1.0.1");
-        Version version3 = new Version("2.0.0");
-        Version version4 = new Version("1.0.0");
+        NativeSemver version1 = new NativeSemver("1.0.0");
+        NativeSemver version2 = new NativeSemver("1.0.1");
+        NativeSemver version3 = new NativeSemver("2.0.0");
+        NativeSemver version4 = new NativeSemver("1.0.0");
 
         assertTrue(version1.isLowerThan(version2));
         assertTrue(version2.isLowerThan(version3));
@@ -1373,8 +1373,8 @@ public class CapacitorUpdaterUnitTest {
 
     @Test
     public void testVersionIsAtLeast() {
-        Version version1 = new Version("1.0.0");
-        Version version2 = new Version("1.0.1");
+        NativeSemver version1 = new NativeSemver("1.0.0");
+        NativeSemver version2 = new NativeSemver("1.0.1");
 
         assertTrue(version2.isAtLeast("1.0.0"));
         assertTrue(version2.isAtLeast("1.0.1"));
@@ -3790,6 +3790,31 @@ public class CapacitorUpdaterUnitTest {
 
         final JSONArray missing = updater.getMissingBundleFiles(manifest, "");
         assertEquals(0, missing.length());
+    }
+
+    @Test
+    public void getMissingBundleFilesReusesUncompressedBuiltinForBrotliEntry() throws Exception {
+        CryptoCipher.setLogger(mock(Logger.class));
+        final Path docsDir = Files.createTempDirectory("capgo-missing-builtin-br-docs");
+        final File filesDir = Files.createTempDirectory("capgo-missing-builtin-br-files").toFile();
+        final File cacheDir = Files.createTempDirectory("capgo-missing-builtin-br-cache").toFile();
+        final Path builtinDir = filesDir.toPath().resolve("public/assets");
+        Files.createDirectories(builtinDir);
+        final byte[] content = "builtin brotli reuse".getBytes(StandardCharsets.UTF_8);
+        Files.write(builtinDir.resolve("app.js"), content);
+        final String hash = CryptoCipher.calcChecksum(builtinDir.resolve("app.js").toFile());
+
+        final CapgoUpdater updater = newDeltaCacheUpdater(docsDir, filesDir, cacheDir);
+        final JSONArray manifest = new JSONArray();
+        final JSONObject entry = new JSONObject();
+        entry.put("file_name", "assets/app.js.br");
+        entry.put("file_hash", hash);
+        manifest.put(entry);
+
+        assertEquals(0, updater.getMissingBundleFiles(manifest, "").length());
+
+        Files.write(builtinDir.resolve("app.js"), "changed".getBytes(StandardCharsets.UTF_8));
+        assertEquals(1, updater.getMissingBundleFiles(manifest, "").length());
     }
 
     @Test

--- a/android/src/test/java/ee/forgr/capacitor_updater/DelayUpdateUtilsTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/DelayUpdateUtilsTest.java
@@ -7,7 +7,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import android.content.SharedPreferences;
-import io.github.g00fy2.versioncompare.Version;
+import ee.forgr.capacitor_updater.NativeSemver;
 import java.util.ArrayList;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -40,7 +40,7 @@ public class DelayUpdateUtilsTest {
         when(editor.remove(anyString())).thenReturn(editor);
         when(editor.commit()).thenReturn(true);
 
-        utils = new DelayUpdateUtils(prefs, editor, new Version("1.0.0"), logger);
+        utils = new DelayUpdateUtils(prefs, editor, new NativeSemver("1.0.0"), logger);
     }
 
     @Test

--- a/android/src/test/java/ee/forgr/capacitor_updater/NativeSemverTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/NativeSemverTest.java
@@ -69,6 +69,23 @@ public class NativeSemverTest {
     }
 
     @Test
+    public void emptyPrereleaseEqualsRelease() {
+        assertEquals(0, new NativeSemver("1.0.0-").compareTo(new NativeSemver("1.0.0")));
+        assertTrue(new NativeSemver("1.0.0-").equals(new NativeSemver("1.0.0")));
+    }
+
+    @Test
+    public void overflowValuesAboveSignedLongMaxCompareCorrectly() {
+        assertTrue(new NativeSemver("9223372036854775808").compareTo(new NativeSemver("9223372036854775809")) < 0);
+        assertTrue(new NativeSemver("9223372036854775809").compareTo(new NativeSemver("9223372036854775808")) > 0);
+    }
+
+    @Test
+    public void oversizedNumericComponentSaturates() {
+        assertEquals(0, new NativeSemver("18446744073709551616").compareTo(new NativeSemver("18446744073709551615")));
+    }
+
+    @Test
     public void unicodeDigitsInCoreAreNotParsedAsNumeric() {
         // Pure Unicode digits yield no ASCII numeric components.
         try {

--- a/android/src/test/java/ee/forgr/capacitor_updater/NativeSemverTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/NativeSemverTest.java
@@ -60,4 +60,24 @@ public class NativeSemverTest {
         assertEquals(new NativeSemver("1.0").hashCode(), new NativeSemver("1.0.0").hashCode());
         assertEquals(new NativeSemver("1.0.0-beta").hashCode(), new NativeSemver("1.0-beta").hashCode());
     }
+
+    @Test
+    public void unicodeNumericPrereleaseIsNotNumericIdentifier() {
+        // Superscript ² is Unicode numeric (No) but not an ASCII digit; treat as non-numeric.
+        assertTrue(new NativeSemver("1.0.0-alpha").compareTo(new NativeSemver("1.0.0-\u00B2")) < 0);
+        assertTrue(new NativeSemver("1.0.0-1").compareTo(new NativeSemver("1.0.0-\u00B2")) < 0);
+    }
+
+    @Test
+    public void unicodeDigitsInCoreAreNotParsedAsNumeric() {
+        // Pure Unicode digits yield no ASCII numeric components.
+        try {
+            new NativeSemver("\u0661\u0662\u0663");
+            throw new AssertionError("expected IllegalArgumentException");
+        } catch (final IllegalArgumentException ignored) {
+            // expected
+        }
+        // Leading Arabic-Indic digit stops the digit run; trailing ASCII digits still parse.
+        assertEquals(0, new NativeSemver("1\u0661.2.3").compareTo(new NativeSemver("1.2.3")));
+    }
 }

--- a/android/src/test/java/ee/forgr/capacitor_updater/NativeSemverTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/NativeSemverTest.java
@@ -16,6 +16,19 @@ public class NativeSemverTest {
     @Test
     public void releaseIsGreaterThanPrereleaseWithSameCore() {
         assertTrue(new NativeSemver("1.0.0").compareTo(new NativeSemver("1.0.0-beta.1")) > 0);
+        assertTrue(new NativeSemver("2.0.0").compareTo(new NativeSemver("2.0.0-beta")) > 0);
+    }
+
+    @Test
+    public void prereleaseOrderingIsDeterministic() {
+        assertTrue(new NativeSemver("2.0.0-beta").compareTo(new NativeSemver("2.0.0-beta.1")) < 0);
+        assertTrue(new NativeSemver("2.0.0-beta.1").compareTo(new NativeSemver("2.0.0-rc.1")) < 0);
+    }
+
+    @Test
+    public void buildMetadataDoesNotAffectPrecedence() {
+        assertEquals(0, new NativeSemver("2.0.0").compareTo(new NativeSemver("2.0.0+build.1")));
+        assertEquals(0, new NativeSemver("2.0.0+build.1").compareTo(new NativeSemver("2.0.0+build.2")));
     }
 
     @Test

--- a/android/src/test/java/ee/forgr/capacitor_updater/NativeSemverTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/NativeSemverTest.java
@@ -36,4 +36,28 @@ public class NativeSemverTest {
         assertEquals("0.0.0", NativeSemver.parseOrDefault("", "0.0.0").toString());
         assertEquals("0.0.0", NativeSemver.parseOrDefault(null, "0.0.0").toString());
     }
+
+    @Test
+    public void betaDotTwoIsLessThanBetaDotTen() {
+        assertTrue(new NativeSemver("1.0.0-beta.2").compareTo(new NativeSemver("1.0.0-beta.10")) < 0);
+        assertTrue(new NativeSemver("1.0.0-beta.10").compareTo(new NativeSemver("1.0.0-beta.2")) > 0);
+    }
+
+    @Test
+    public void numericPrereleaseIdentifierPrecedesNonNumeric() {
+        assertTrue(new NativeSemver("1.0.0-1").compareTo(new NativeSemver("1.0.0-alpha")) < 0);
+        assertTrue(new NativeSemver("1.0.0-alpha.1").compareTo(new NativeSemver("1.0.0-alpha.beta")) < 0);
+    }
+
+    @Test
+    public void underscoreSeparatesNumericCoreComponents() {
+        assertEquals(0, new NativeSemver("1.2_3").compareTo(new NativeSemver("1.2.3")));
+        assertTrue(new NativeSemver("1.2_3").compareTo(new NativeSemver("1.2")) > 0);
+    }
+
+    @Test
+    public void hashCodeMatchesEqualsForZeroPaddedVersions() {
+        assertEquals(new NativeSemver("1.0").hashCode(), new NativeSemver("1.0.0").hashCode());
+        assertEquals(new NativeSemver("1.0.0-beta").hashCode(), new NativeSemver("1.0-beta").hashCode());
+    }
 }

--- a/android/src/test/java/ee/forgr/capacitor_updater/NativeSemverTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/NativeSemverTest.java
@@ -1,0 +1,26 @@
+package ee.forgr.capacitor_updater;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class NativeSemverTest {
+
+    @Test
+    public void treatsOneZeroAsEqualToOneZeroZero() {
+        assertEquals(0, new NativeSemver("1.0").compareTo(new NativeSemver("1.0.0")));
+        assertTrue(new NativeSemver("1.0").equals(new NativeSemver("1.0.0")));
+    }
+
+    @Test
+    public void releaseIsGreaterThanPrereleaseWithSameCore() {
+        assertTrue(new NativeSemver("1.0.0").compareTo(new NativeSemver("1.0.0-beta.1")) > 0);
+    }
+
+    @Test
+    public void parseOrDefaultFallsBackForEmptyVersion() {
+        assertEquals("0.0.0", NativeSemver.parseOrDefault("", "0.0.0").toString());
+        assertEquals("0.0.0", NativeSemver.parseOrDefault(null, "0.0.0").toString());
+    }
+}

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -8,7 +8,6 @@ import Foundation
 import Capacitor
 import UIKit
 import WebKit
-import Version
 
 /**
  * Please read the Capacitor iOS Plugin Development Guide
@@ -147,7 +146,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     // Note: DELAY_CONDITION_PREFERENCES is now defined in DelayUpdateUtils.DELAY_CONDITION_PREFERENCES
     private var updateUrl = ""
     private var backgroundTaskID: UIBackgroundTaskIdentifier = UIBackgroundTaskIdentifier.invalid
-    private var currentVersionNative: Version = "0.0.0"
+    private var currentVersionNative: NativeSemver = (try? NativeSemver("0.0.0"))!
     private var currentBuildVersion: String = "0"
     private var autoUpdate = false
     private var autoUpdateMode = CapacitorUpdaterPlugin.autoUpdateModeOff
@@ -262,7 +261,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             fatalError("Cannot get version name")
         }
         do {
-            currentVersionNative = try Version(versionName)
+            currentVersionNative = try NativeSemver(versionName)
         } catch {
             logger.error("Cannot parse versionName \(versionName)")
         }
@@ -4892,8 +4891,8 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                         // Determine update availability by comparing versions
                         if let availableVersion = availableVersion {
                             do {
-                                let currentVer = try Version(currentVersionName)
-                                let availableVer = try Version(availableVersion)
+                                let currentVer = try NativeSemver(currentVersionName)
+                                let availableVer = try NativeSemver(availableVersion)
                                 if availableVer > currentVer {
                                     result["updateAvailability"] = AppUpdateAvailability.updateAvailable.rawValue
                                 } else {

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -260,11 +260,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             // crash the app on purpose
             fatalError("Cannot get version name")
         }
-        do {
-            currentVersionNative = try NativeSemver(versionName)
-        } catch {
-            logger.error("Cannot parse versionName \(versionName)")
-        }
+        currentVersionNative = NativeSemver.parseOrDefault(versionName)
         currentBuildVersion = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
         logger.info("version native \(self.currentVersionNative.description)")
         implementation.versionBuild = getConfig().getString("version", Bundle.main.versionName)!

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -260,7 +260,12 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             // crash the app on purpose
             fatalError("Cannot get version name")
         }
-        currentVersionNative = NativeSemver.parseOrDefault(versionName)
+        do {
+            currentVersionNative = try NativeSemver(versionName)
+        } catch {
+            logger.error("Cannot parse versionName \(versionName), falling back to 0.0.0")
+            currentVersionNative = NativeSemver.parseOrDefault(versionName)
+        }
         currentBuildVersion = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
         logger.info("version native \(self.currentVersionNative.description)")
         implementation.versionBuild = getConfig().getString("version", Bundle.main.versionName)!

--- a/ios/Sources/CapacitorUpdaterPlugin/DelayUpdateUtils.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/DelayUpdateUtils.swift
@@ -13,7 +13,6 @@
 //
 
 import Foundation
-import Version
 
 public class DelayUpdateUtils {
 
@@ -23,7 +22,7 @@ public class DelayUpdateUtils {
     // swiftlint:enable identifier_name
     private let logger: Logger
 
-    private let currentVersionNative: Version
+    private let currentVersionNative: NativeSemver
 
     public enum CancelDelaySource {
         case killed
@@ -39,7 +38,7 @@ public class DelayUpdateUtils {
         }
     }
 
-    public init(currentVersionNative: Version, logger: Logger) {
+    public init(currentVersionNative: NativeSemver, logger: Logger) {
         self.currentVersionNative = currentVersionNative
         self.logger = logger
     }
@@ -117,7 +116,7 @@ public class DelayUpdateUtils {
             case "nativeVersion":
                 if let value = value, !value.isEmpty {
                     do {
-                        let versionLimit = try Version(value)
+                        let versionLimit = try NativeSemver(value)
                         if currentVersionNative >= versionLimit {
                             // swiftlint:disable:next line_length
                             logger.info("Native version delay (value: \(value)) condition removed due to above limit at index \(index)")

--- a/ios/Sources/CapacitorUpdaterPlugin/NativeSemver.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/NativeSemver.swift
@@ -2,11 +2,11 @@ import Foundation
 
 /// Lightweight semver-style comparator for native app version strings.
 /// Replaces the third-party Version dependency for delay-update checks.
-struct NativeSemver: Comparable, CustomStringConvertible {
+public struct NativeSemver: Comparable, CustomStringConvertible {
     private let original: String
     private let numericParts: [Int]
 
-    init(_ version: String) throws {
+    public init(_ version: String) throws {
         guard !version.isEmpty else {
             throw NativeSemverError.empty
         }
@@ -18,11 +18,11 @@ struct NativeSemver: Comparable, CustomStringConvertible {
         self.numericParts = parts
     }
 
-    var description: String {
+    public var description: String {
         original
     }
 
-    static func < (lhs: NativeSemver, rhs: NativeSemver) -> Bool {
+    public static func < (lhs: NativeSemver, rhs: NativeSemver) -> Bool {
         let maxCount = max(lhs.numericParts.count, rhs.numericParts.count)
         for index in 0..<maxCount {
             let left = index < lhs.numericParts.count ? lhs.numericParts[index] : 0
@@ -56,7 +56,7 @@ struct NativeSemver: Comparable, CustomStringConvertible {
     }
 }
 
-enum NativeSemverError: Error {
+public enum NativeSemverError: Error {
     case empty
     case noNumericComponents(String)
 }

--- a/ios/Sources/CapacitorUpdaterPlugin/NativeSemver.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/NativeSemver.swift
@@ -66,11 +66,65 @@ public struct NativeSemver: Comparable, CustomStringConvertible, Equatable {
         case (_, nil):
             return -1
         case let (left?, right?):
-            if left == right {
+            return Self.comparePrerelease(left, right)
+        }
+    }
+
+    private static func comparePrerelease(_ left: String, _ right: String) -> Int {
+        let leftIds = left.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+        let rightIds = right.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+        let maxCount = max(leftIds.count, rightIds.count)
+        for index in 0..<maxCount {
+            if index >= leftIds.count {
+                return -1
+            }
+            if index >= rightIds.count {
+                return 1
+            }
+            let cmp = comparePrereleaseIdentifier(leftIds[index], rightIds[index])
+            if cmp != 0 {
+                return cmp
+            }
+        }
+        return 0
+    }
+
+    private static func comparePrereleaseIdentifier(_ left: String, _ right: String) -> Int {
+        let leftNumeric = isNumericIdentifier(left)
+        let rightNumeric = isNumericIdentifier(right)
+        if leftNumeric && rightNumeric {
+            let leftDigits = stripLeadingZeros(left)
+            let rightDigits = stripLeadingZeros(right)
+            if leftDigits.count != rightDigits.count {
+                return leftDigits.count < rightDigits.count ? -1 : 1
+            }
+            if leftDigits == rightDigits {
                 return 0
             }
-            return left < right ? -1 : 1
+            return leftDigits < rightDigits ? -1 : 1
         }
+        if leftNumeric {
+            return -1
+        }
+        if rightNumeric {
+            return 1
+        }
+        if left == right {
+            return 0
+        }
+        return left < right ? -1 : 1
+    }
+
+    private static func isNumericIdentifier(_ value: String) -> Bool {
+        !value.isEmpty && value.allSatisfy { $0.isNumber }
+    }
+
+    private static func stripLeadingZeros(_ digits: String) -> String {
+        var result = digits
+        while result.count > 1 && result.first == "0" {
+            result.removeFirst()
+        }
+        return result
     }
 
     private static func splitCoreAndPrerelease(_ version: String) -> (core: String, prerelease: String?) {
@@ -88,7 +142,7 @@ public struct NativeSemver: Comparable, CustomStringConvertible, Equatable {
 
     private static func parseNumericParts(_ core: String) -> [UInt64] {
         var parts: [UInt64] = []
-        for segment in core.split(separator: ".", omittingEmptySubsequences: false) {
+        for segment in core.replacingOccurrences(of: "_", with: ".").split(separator: ".", omittingEmptySubsequences: false) {
             guard !segment.isEmpty else {
                 continue
             }
@@ -111,7 +165,7 @@ public struct NativeSemver: Comparable, CustomStringConvertible, Equatable {
         if digits.count > 20 {
             return UInt64.max
         }
-        return UInt64(digits)
+        return UInt64(digits) ?? UInt64.max
     }
 }
 

--- a/ios/Sources/CapacitorUpdaterPlugin/NativeSemver.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/NativeSemver.swift
@@ -115,8 +115,17 @@ public struct NativeSemver: Comparable, CustomStringConvertible, Equatable {
         return left < right ? -1 : 1
     }
 
+    /// SemVer numeric identifiers are ASCII digits only (`0`–`9`), not Unicode Nd/No.
+    private static func isAsciiDigit(_ scalar: Unicode.Scalar) -> Bool {
+        scalar.value >= 48 && scalar.value <= 57
+    }
+
+    private static func isAsciiDigit(_ character: Character) -> Bool {
+        character.unicodeScalars.count == 1 && isAsciiDigit(character.unicodeScalars.first!)
+    }
+
     private static func isNumericIdentifier(_ value: String) -> Bool {
-        !value.isEmpty && value.allSatisfy { $0.isNumber }
+        !value.isEmpty && value.unicodeScalars.allSatisfy(isAsciiDigit)
     }
 
     private static func stripLeadingZeros(_ digits: String) -> String {
@@ -149,7 +158,7 @@ public struct NativeSemver: Comparable, CustomStringConvertible, Equatable {
             var end = 0
             while end < segment.count {
                 let scalar = segment[segment.index(segment.startIndex, offsetBy: end)]
-                if !scalar.isNumber {
+                if !isAsciiDigit(scalar) {
                     break
                 }
                 end += 1

--- a/ios/Sources/CapacitorUpdaterPlugin/NativeSemver.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/NativeSemver.swift
@@ -2,41 +2,93 @@ import Foundation
 
 /// Lightweight semver-style comparator for native app version strings.
 /// Replaces the third-party Version dependency for delay-update checks.
-public struct NativeSemver: Comparable, CustomStringConvertible {
+public struct NativeSemver: Comparable, CustomStringConvertible, Equatable {
     private let original: String
-    private let numericParts: [Int]
+    private let numericParts: [UInt64]
+    private let prerelease: String?
+
+    public static func parseOrDefault(_ version: String?, fallback: String = "0.0.0") -> NativeSemver {
+        guard let version, !version.isEmpty else {
+            return (try? NativeSemver(fallback)) ?? NativeSemver(fallback: fallback)
+        }
+        return (try? NativeSemver(version)) ?? NativeSemver(fallback: fallback)
+    }
 
     public init(_ version: String) throws {
         guard !version.isEmpty else {
             throw NativeSemverError.empty
         }
-        let parts = Self.parseNumericParts(version)
+        let core = Self.splitCoreAndPrerelease(version)
+        let parts = Self.parseNumericParts(core.core)
         guard !parts.isEmpty else {
             throw NativeSemverError.noNumericComponents(version)
         }
         self.original = version
         self.numericParts = parts
+        self.prerelease = core.prerelease
+    }
+
+    private init(fallback: String) {
+        self.original = fallback
+        self.numericParts = [0, 0, 0]
+        self.prerelease = nil
     }
 
     public var description: String {
         original
     }
 
-    public static func < (lhs: NativeSemver, rhs: NativeSemver) -> Bool {
-        let maxCount = max(lhs.numericParts.count, rhs.numericParts.count)
-        for index in 0..<maxCount {
-            let left = index < lhs.numericParts.count ? lhs.numericParts[index] : 0
-            let right = index < rhs.numericParts.count ? rhs.numericParts[index] : 0
-            if left != right {
-                return left < right
-            }
-        }
-        return false
+    public static func == (lhs: NativeSemver, rhs: NativeSemver) -> Bool {
+        lhs.compareCoreAndPrerelease(to: rhs) == 0
     }
 
-    private static func parseNumericParts(_ version: String) -> [Int] {
-        var parts: [Int] = []
-        for segment in version.split(whereSeparator: { $0 == "." || $0 == "-" || $0 == "+" || $0 == "_" }) {
+    public static func < (lhs: NativeSemver, rhs: NativeSemver) -> Bool {
+        lhs.compareCoreAndPrerelease(to: rhs) < 0
+    }
+
+    private func compareCoreAndPrerelease(to other: NativeSemver) -> Int {
+        let maxCount = max(numericParts.count, other.numericParts.count)
+        for index in 0..<maxCount {
+            let left = index < numericParts.count ? numericParts[index] : 0
+            let right = index < other.numericParts.count ? other.numericParts[index] : 0
+            if left < right {
+                return -1
+            }
+            if left > right {
+                return 1
+            }
+        }
+        switch (prerelease, other.prerelease) {
+        case (nil, nil):
+            return 0
+        case (nil, _):
+            return 1
+        case (_, nil):
+            return -1
+        case let (left?, right?):
+            if left == right {
+                return 0
+            }
+            return left < right ? -1 : 1
+        }
+    }
+
+    private static func splitCoreAndPrerelease(_ version: String) -> (core: String, prerelease: String?) {
+        var working = version
+        if let plusIndex = working.firstIndex(of: "+") {
+            working = String(working[..<plusIndex])
+        }
+        if let dashIndex = working.firstIndex(of: "-") {
+            let core = String(working[..<dashIndex])
+            let prerelease = String(working[working.index(after: dashIndex)...])
+            return (core, prerelease.isEmpty ? nil : prerelease)
+        }
+        return (working, nil)
+    }
+
+    private static func parseNumericParts(_ core: String) -> [UInt64] {
+        var parts: [UInt64] = []
+        for segment in core.split(separator: ".", omittingEmptySubsequences: false) {
             guard !segment.isEmpty else {
                 continue
             }
@@ -48,11 +100,18 @@ public struct NativeSemver: Comparable, CustomStringConvertible {
                 }
                 end += 1
             }
-            if end > 0, let value = Int(segment.prefix(end)) {
+            if end > 0, let value = parseNumericComponent(String(segment.prefix(end))) {
                 parts.append(value)
             }
         }
         return parts
+    }
+
+    private static func parseNumericComponent(_ digits: String) -> UInt64? {
+        if digits.count > 20 {
+            return UInt64.max
+        }
+        return UInt64(digits)
     }
 }
 

--- a/ios/Sources/CapacitorUpdaterPlugin/NativeSemver.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/NativeSemver.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Lightweight semver-style comparator for native app version strings.
+/// Replaces the third-party Version dependency for delay-update checks.
+struct NativeSemver: Comparable, CustomStringConvertible {
+    private let original: String
+    private let numericParts: [Int]
+
+    init(_ version: String) throws {
+        guard !version.isEmpty else {
+            throw NativeSemverError.empty
+        }
+        let parts = Self.parseNumericParts(version)
+        guard !parts.isEmpty else {
+            throw NativeSemverError.noNumericComponents(version)
+        }
+        self.original = version
+        self.numericParts = parts
+    }
+
+    var description: String {
+        original
+    }
+
+    static func < (lhs: NativeSemver, rhs: NativeSemver) -> Bool {
+        let maxCount = max(lhs.numericParts.count, rhs.numericParts.count)
+        for index in 0..<maxCount {
+            let left = index < lhs.numericParts.count ? lhs.numericParts[index] : 0
+            let right = index < rhs.numericParts.count ? rhs.numericParts[index] : 0
+            if left != right {
+                return left < right
+            }
+        }
+        return false
+    }
+
+    private static func parseNumericParts(_ version: String) -> [Int] {
+        var parts: [Int] = []
+        for segment in version.split(whereSeparator: { $0 == "." || $0 == "-" || $0 == "+" || $0 == "_" }) {
+            guard !segment.isEmpty else {
+                continue
+            }
+            var end = 0
+            while end < segment.count {
+                let scalar = segment[segment.index(segment.startIndex, offsetBy: end)]
+                if !scalar.isNumber {
+                    break
+                }
+                end += 1
+            }
+            if end > 0, let value = Int(segment.prefix(end)) {
+                parts.append(value)
+            }
+        }
+        return parts
+    }
+}
+
+enum NativeSemverError: Error {
+    case empty
+    case noNumericComponents(String)
+}

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 @testable import CapacitorUpdaterPlugin
 import Capacitor
-import Version
 
 private class TestableCapacitorUpdaterPlugin: CapacitorUpdaterPlugin {
     private(set) var notifiedEventNames: [String] = []
@@ -560,7 +559,7 @@ class CapacitorUpdaterTests: XCTestCase {
 
     private func makeDelayUpdateUtils() throws -> DelayUpdateUtils {
         let logger = Logger(withTag: "TestLogger")
-        let version = try Version("1.0.0")
+        let version = try NativeSemver("1.0.0")
         return DelayUpdateUtils(currentVersionNative: version, logger: logger)
     }
 

--- a/ios/Tests/CapacitorUpdaterPluginTests/NativeSemverTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/NativeSemverTests.swift
@@ -33,6 +33,15 @@ final class NativeSemverTests: XCTestCase {
         XCTAssertEqual(oversized, maxRepresentable)
     }
 
+    func testEmptyPrereleaseEqualsRelease() throws {
+        XCTAssertEqual(try NativeSemver("1.0.0-"), try NativeSemver("1.0.0"))
+    }
+
+    func testOverflowValuesAboveSignedLongMaxCompareCorrectly() throws {
+        XCTAssertLessThan(try NativeSemver("9223372036854775808"), try NativeSemver("9223372036854775809"))
+        XCTAssertGreaterThan(try NativeSemver("9223372036854775809"), try NativeSemver("9223372036854775808"))
+    }
+
     func testUnicodeNumericPrereleaseIsNotNumericIdentifier() throws {
         // Superscript ² is Unicode numeric (No) but not an ASCII digit; treat as non-numeric.
         // With Character.isNumber, ² would be numeric and precede "alpha"; ASCII-only keeps lexical order.

--- a/ios/Tests/CapacitorUpdaterPluginTests/NativeSemverTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/NativeSemverTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import CapacitorUpdaterPlugin
+
+final class NativeSemverTests: XCTestCase {
+    func testZeroPaddedCoreEquality() throws {
+        XCTAssertEqual(try NativeSemver("1.0"), try NativeSemver("1.0.0"))
+    }
+
+    func testReleaseGreaterThanPrerelease() throws {
+        XCTAssertGreaterThan(try NativeSemver("1.0.0"), try NativeSemver("1.0.0-beta.1"))
+        XCTAssertGreaterThan(try NativeSemver("2.0.0"), try NativeSemver("2.0.0-beta"))
+    }
+
+    func testPrereleaseNumericIdentifiersCompareNumerically() throws {
+        XCTAssertLessThan(try NativeSemver("1.0.0-beta.2"), try NativeSemver("1.0.0-beta.10"))
+        XCTAssertLessThan(try NativeSemver("1.0.0-1"), try NativeSemver("1.0.0-alpha"))
+        XCTAssertLessThan(try NativeSemver("1.0.0-alpha.1"), try NativeSemver("1.0.0-alpha.beta"))
+    }
+
+    func testBuildMetadataIgnored() throws {
+        XCTAssertEqual(try NativeSemver("2.0.0"), try NativeSemver("2.0.0+build.1"))
+    }
+
+    func testUnderscoreSeparatesNumericCoreComponents() throws {
+        XCTAssertEqual(try NativeSemver("1.2_3"), try NativeSemver("1.2.3"))
+        XCTAssertGreaterThan(try NativeSemver("1.2_3"), try NativeSemver("1.2"))
+    }
+
+    func testOversizedNumericComponentSaturates() throws {
+        // 2^64 == 18446744073709551616 overflows UInt64 and must saturate, not be omitted.
+        let oversized = try NativeSemver("18446744073709551616")
+        let maxRepresentable = try NativeSemver(String(UInt64.max))
+        XCTAssertEqual(oversized, maxRepresentable)
+    }
+}

--- a/ios/Tests/CapacitorUpdaterPluginTests/NativeSemverTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/NativeSemverTests.swift
@@ -32,4 +32,19 @@ final class NativeSemverTests: XCTestCase {
         let maxRepresentable = try NativeSemver(String(UInt64.max))
         XCTAssertEqual(oversized, maxRepresentable)
     }
+
+    func testUnicodeNumericPrereleaseIsNotNumericIdentifier() throws {
+        // Superscript ² is Unicode numeric (No) but not an ASCII digit; treat as non-numeric.
+        // With Character.isNumber, ² would be numeric and precede "alpha"; ASCII-only keeps lexical order.
+        XCTAssertLessThan(try NativeSemver("1.0.0-alpha"), try NativeSemver("1.0.0-²"))
+        XCTAssertLessThan(try NativeSemver("1.0.0-1"), try NativeSemver("1.0.0-²"))
+    }
+
+    func testUnicodeDigitsInCoreAreNotParsedAsNumeric() throws {
+        // Pure Unicode digits yield no ASCII numeric components.
+        XCTAssertThrowsError(try NativeSemver("١٢٣"))
+        // Leading Arabic-Indic digit stops the digit run; trailing ASCII digits still parse.
+        let mixed = try NativeSemver("1١.2.3")
+        XCTAssertEqual(mixed, try NativeSemver("1.2.3"))
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Add in-tree `NativeSemver` on iOS and Android
- Remove `mrackwitz/Version` (SPM/CocoaPods) and `io.github.g00fy2:versioncompare`
- Add Android regression test: Brotli manifest entries reuse uncompressed builtin assets

## Why
Delay-update `nativeVersion` checks and App Store availability comparison only need numeric semver-style ordering. A tiny native helper avoids two third-party packages.

## How
Parse dot-separated numeric segments (also `-`, `+`, `_` delimiters) and compare lexicographically with implicit zero padding — matching prior behavior for common `x.y.z` native versions.

## Testing
- Updated existing version comparison unit tests on Android
- Updated `DelayUpdateUtils` / plugin tests on iOS
- New `getMissingBundleFilesReusesUncompressedBuiltinForBrotliEntry` documents Android already strips `.br` via `resolveManifestBuiltinFile` (no prod fix required; mirrors iOS #888 intent)

## Not Tested
- Full `bun run verify` locally (no Android SDK / Xcode in agent VM); CI to validate.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-975dd7ca-d4aa-44b7-bc22-c8d08712ecab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-975dd7ca-d4aa-44b7-bc22-c8d08712ecab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-updater/pr/892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791472951&installation_model_id=430928&pr_number=892&repository=Cap-go%2Fcapacitor-updater&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-updater%2Fpull%2F892&signature=34e477ff1bafd291d2868e5dffd71292eb5082251c2d1ef434f3cf0277b3fdeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-updater/pull/892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved native version comparison across Android and iOS, including prerelease and build metadata handling.
  - Added safer fallback handling for empty, invalid, or missing version values.
  - Improved Brotli-compressed asset handling by reusing matching built-in content and detecting changed content correctly.

- **Chores**
  - Replaced the external version-comparison component with built-in platform support.
  - Improved reliability of automated asset uploads and test downloads with retry handling and fallback artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->