### PR TITLE
refactor(ios): replace Alamofire with URLSession

### DIFF
--- a/.github/actions/download-artifact-ladder/action.yml
+++ b/.github/actions/download-artifact-ladder/action.yml
@@ -1,0 +1,68 @@
+name: Download artifact with retry ladder
+description: >-
+  Download a GitHub Actions artifact with two primary retries and -r2/-r3 fallback
+  names. Each later attempt runs only when every prior attempt did not succeed.
+inputs:
+  artifact-name:
+    description: Primary artifact name. Fallbacks use `${name}-r2` and `${name}-r3`.
+    required: true
+  path:
+    description: Download destination path.
+    required: true
+  retry-delay-seconds:
+    description: Delay between attempts in seconds.
+    default: '15'
+  max-retry-delay-seconds:
+    description: Maximum total sleep across all retry waits in this ladder.
+    default: '45'
+  sleep-counter-file:
+    description: Optional file tracking cumulative retry sleep for shared budgets across ladders.
+    default: ''
+runs:
+  using: composite
+  steps:
+    - id: download_primary_1
+      name: Download ${{ inputs.artifact-name }} (attempt 1)
+      continue-on-error: true
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.path }}
+    - id: wait_primary_2
+      name: Wait before retrying download
+      if: steps.download_primary_1.outcome != 'success'
+      shell: bash
+      run: ./.github/actions/download-artifact-ladder/sleep-capped.sh "${{ inputs.retry-delay-seconds }}" "${{ inputs.max-retry-delay-seconds }}" "${{ inputs.sleep-counter-file }}"
+    - id: download_primary_2
+      name: Download ${{ inputs.artifact-name }} (attempt 2)
+      if: steps.download_primary_1.outcome != 'success'
+      continue-on-error: true
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.path }}
+    - id: wait_r2
+      name: Wait before fallback download
+      if: steps.download_primary_1.outcome != 'success' && steps.download_primary_2.outcome != 'success'
+      shell: bash
+      run: ./.github/actions/download-artifact-ladder/sleep-capped.sh "${{ inputs.retry-delay-seconds }}" "${{ inputs.max-retry-delay-seconds }}" "${{ inputs.sleep-counter-file }}"
+    - id: download_r2
+      name: Download ${{ inputs.artifact-name }}-r2 (fallback)
+      if: steps.download_primary_1.outcome != 'success' && steps.download_primary_2.outcome != 'success'
+      continue-on-error: true
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.artifact-name }}-r2
+        path: ${{ inputs.path }}
+    - id: wait_r3
+      name: Wait before final fallback download
+      if: steps.download_primary_1.outcome != 'success' && steps.download_primary_2.outcome != 'success' && steps.download_r2.outcome != 'success'
+      shell: bash
+      run: ./.github/actions/download-artifact-ladder/sleep-capped.sh "${{ inputs.retry-delay-seconds }}" "${{ inputs.max-retry-delay-seconds }}" "${{ inputs.sleep-counter-file }}"
+    - id: download_r3
+      name: Download ${{ inputs.artifact-name }}-r3 (final fallback)
+      if: steps.download_primary_1.outcome != 'success' && steps.download_primary_2.outcome != 'success' && steps.download_r2.outcome != 'success'
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.artifact-name }}-r3
+        path: ${{ inputs.path }}

--- a/.github/actions/download-artifact-ladder/sleep-capped.sh
+++ b/.github/actions/download-artifact-ladder/sleep-capped.sh
@@ -26,6 +26,6 @@ if [[ "$sleep_seconds" -gt "$remaining" ]]; then
   sleep_seconds="$remaining"
 fi
 
-echo "Sleeping ${sleep_seconds}s before artifact download retry (${current_total}s / ${max_total_seconds}s used)."
+echo "Sleeping ${sleep_seconds}s before artifact retry (${current_total}s / ${max_total_seconds}s used)."
 sleep "$sleep_seconds"
 echo "$((current_total + sleep_seconds))" >"$counter_file"

--- a/.github/actions/download-artifact-ladder/sleep-capped.sh
+++ b/.github/actions/download-artifact-ladder/sleep-capped.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 delay_seconds="${1:?delay seconds required}"
 max_total_seconds="${2:?max total seconds required}"
-counter_file="${RUNNER_TEMP}/artifact-ladder-sleep-total"
+counter_file="${RUNNER_TEMP}/artifact-download-ladder-sleep-total"
 if [[ -n "${3:-}" ]]; then
   counter_file="$3"
 fi

--- a/.github/actions/download-artifact-ladder/sleep-capped.sh
+++ b/.github/actions/download-artifact-ladder/sleep-capped.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+delay_seconds="${1:?delay seconds required}"
+max_total_seconds="${2:?max total seconds required}"
+counter_file="${RUNNER_TEMP}/artifact-ladder-sleep-total"
+if [[ -n "${3:-}" ]]; then
+  counter_file="$3"
+fi
+
+current_total=0
+if [[ -f "$counter_file" ]]; then
+  current_total="$(cat "$counter_file")"
+fi
+
+remaining=$((max_total_seconds - current_total))
+if [[ "$remaining" -le 0 ]]; then
+  echo "Artifact ladder retry delay budget exhausted (${current_total}s / ${max_total_seconds}s)."
+  exit 0
+fi
+
+sleep_seconds="$delay_seconds"
+if [[ "$sleep_seconds" -gt "$remaining" ]]; then
+  sleep_seconds="$remaining"
+fi
+
+echo "Sleeping ${sleep_seconds}s before artifact download retry (${current_total}s / ${max_total_seconds}s used)."
+sleep "$sleep_seconds"
+echo "$((current_total + sleep_seconds))" >"$counter_file"

--- a/.github/actions/download-artifact-ladder/sleep-capped.sh
+++ b/.github/actions/download-artifact-ladder/sleep-capped.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Caps cumulative retry sleep. Callers may pass a shared counter file so multiple
+# ladders in one job share a single budget (see maestro_android_example_app).
 set -euo pipefail
 
 delay_seconds="${1:?delay seconds required}"

--- a/.github/actions/upload-artifact-ladder/action.yml
+++ b/.github/actions/upload-artifact-ladder/action.yml
@@ -1,0 +1,48 @@
+name: Upload artifact with retry ladder
+description: >-
+  Upload a GitHub Actions artifact with two retries. Later attempts use -r2 and -r3
+  suffixes and run only when every prior upload did not succeed.
+inputs:
+  artifact-name:
+    description: Primary artifact name. Fallbacks use `${name}-r2` and `${name}-r3`.
+    required: true
+  path:
+    description: Files to upload.
+    required: true
+  if-no-files-found:
+    description: Behavior when no files are found.
+    default: error
+  include-hidden-files:
+    description: Whether to include hidden files.
+    default: 'false'
+runs:
+  using: composite
+  steps:
+    - id: upload_primary_1
+      name: Upload ${{ inputs.artifact-name }} (attempt 1)
+      continue-on-error: true
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.path }}
+        if-no-files-found: ${{ inputs.if-no-files-found }}
+        include-hidden-files: ${{ inputs.include-hidden-files }}
+    - id: upload_primary_2
+      name: Upload ${{ inputs.artifact-name }}-r2 (attempt 2)
+      if: steps.upload_primary_1.outcome != 'success'
+      continue-on-error: true
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.artifact-name }}-r2
+        path: ${{ inputs.path }}
+        if-no-files-found: ${{ inputs.if-no-files-found }}
+        include-hidden-files: ${{ inputs.include-hidden-files }}
+    - id: upload_primary_3
+      name: Upload ${{ inputs.artifact-name }}-r3 (attempt 3)
+      if: steps.upload_primary_1.outcome != 'success' && steps.upload_primary_2.outcome != 'success'
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.artifact-name }}-r3
+        path: ${{ inputs.path }}
+        if-no-files-found: ${{ inputs.if-no-files-found }}
+        include-hidden-files: ${{ inputs.include-hidden-files }}

--- a/.github/actions/upload-artifact-ladder/action.yml
+++ b/.github/actions/upload-artifact-ladder/action.yml
@@ -37,7 +37,7 @@ runs:
       name: Wait before retrying upload
       if: steps.upload_primary_1.outcome != 'success'
       shell: bash
-      run: ./.github/actions/download-artifact-ladder/sleep-capped.sh "${{ inputs.retry-delay-seconds }}" "${{ inputs.max-retry-delay-seconds }}"
+      run: ./.github/actions/download-artifact-ladder/sleep-capped.sh "${{ inputs.retry-delay-seconds }}" "${{ inputs.max-retry-delay-seconds }}" "${RUNNER_TEMP}/artifact-upload-ladder-sleep-total"
     - id: upload_primary_2
       name: Upload ${{ inputs.artifact-name }}-r2 (attempt 2)
       if: steps.upload_primary_1.outcome != 'success'
@@ -52,7 +52,7 @@ runs:
       name: Wait before final upload
       if: steps.upload_primary_1.outcome != 'success' && steps.upload_primary_2.outcome != 'success'
       shell: bash
-      run: ./.github/actions/download-artifact-ladder/sleep-capped.sh "${{ inputs.retry-delay-seconds }}" "${{ inputs.max-retry-delay-seconds }}"
+      run: ./.github/actions/download-artifact-ladder/sleep-capped.sh "${{ inputs.retry-delay-seconds }}" "${{ inputs.max-retry-delay-seconds }}" "${RUNNER_TEMP}/artifact-upload-ladder-sleep-total"
     - id: upload_primary_3
       name: Upload ${{ inputs.artifact-name }}-r3 (attempt 3)
       if: steps.upload_primary_1.outcome != 'success' && steps.upload_primary_2.outcome != 'success'

--- a/.github/actions/upload-artifact-ladder/action.yml
+++ b/.github/actions/upload-artifact-ladder/action.yml
@@ -15,6 +15,12 @@ inputs:
   include-hidden-files:
     description: Whether to include hidden files.
     default: 'false'
+  retry-delay-seconds:
+    description: Delay between attempts in seconds.
+    default: '15'
+  max-retry-delay-seconds:
+    description: Maximum total sleep across all retry waits in this ladder.
+    default: '30'
 runs:
   using: composite
   steps:
@@ -27,6 +33,11 @@ runs:
         path: ${{ inputs.path }}
         if-no-files-found: ${{ inputs.if-no-files-found }}
         include-hidden-files: ${{ inputs.include-hidden-files }}
+    - id: wait_primary_2
+      name: Wait before retrying upload
+      if: steps.upload_primary_1.outcome != 'success'
+      shell: bash
+      run: ./.github/actions/download-artifact-ladder/sleep-capped.sh "${{ inputs.retry-delay-seconds }}" "${{ inputs.max-retry-delay-seconds }}"
     - id: upload_primary_2
       name: Upload ${{ inputs.artifact-name }}-r2 (attempt 2)
       if: steps.upload_primary_1.outcome != 'success'
@@ -37,6 +48,11 @@ runs:
         path: ${{ inputs.path }}
         if-no-files-found: ${{ inputs.if-no-files-found }}
         include-hidden-files: ${{ inputs.include-hidden-files }}
+    - id: wait_primary_3
+      name: Wait before final upload
+      if: steps.upload_primary_1.outcome != 'success' && steps.upload_primary_2.outcome != 'success'
+      shell: bash
+      run: ./.github/actions/download-artifact-ladder/sleep-capped.sh "${{ inputs.retry-delay-seconds }}" "${{ inputs.max-retry-delay-seconds }}"
     - id: upload_primary_3
       name: Upload ${{ inputs.artifact-name }}-r3 (attempt 3)
       if: steps.upload_primary_1.outcome != 'success' && steps.upload_primary_2.outcome != 'success'

--- a/.github/actions/upload-artifact-ladder/action.yml
+++ b/.github/actions/upload-artifact-ladder/action.yml
@@ -21,6 +21,11 @@ inputs:
   max-retry-delay-seconds:
     description: Maximum total sleep across all retry waits in this ladder.
     default: '30'
+  sleep-counter-file:
+    description: >-
+      Optional file tracking cumulative retry sleep. Defaults to an upload-specific
+      counter so download ladders in the same job cannot consume this budget.
+    default: ''
 runs:
   using: composite
   steps:
@@ -37,7 +42,15 @@ runs:
       name: Wait before retrying upload
       if: steps.upload_primary_1.outcome != 'success'
       shell: bash
-      run: ./.github/actions/download-artifact-ladder/sleep-capped.sh "${{ inputs.retry-delay-seconds }}" "${{ inputs.max-retry-delay-seconds }}" "${RUNNER_TEMP}/artifact-upload-ladder-sleep-total"
+      run: |
+        counter_file="${{ inputs.sleep-counter-file }}"
+        if [[ -z "$counter_file" ]]; then
+          counter_file="${RUNNER_TEMP}/artifact-upload-ladder-sleep-total"
+        fi
+        ./.github/actions/download-artifact-ladder/sleep-capped.sh \
+          "${{ inputs.retry-delay-seconds }}" \
+          "${{ inputs.max-retry-delay-seconds }}" \
+          "$counter_file"
     - id: upload_primary_2
       name: Upload ${{ inputs.artifact-name }}-r2 (attempt 2)
       if: steps.upload_primary_1.outcome != 'success'
@@ -52,7 +65,15 @@ runs:
       name: Wait before final upload
       if: steps.upload_primary_1.outcome != 'success' && steps.upload_primary_2.outcome != 'success'
       shell: bash
-      run: ./.github/actions/download-artifact-ladder/sleep-capped.sh "${{ inputs.retry-delay-seconds }}" "${{ inputs.max-retry-delay-seconds }}" "${RUNNER_TEMP}/artifact-upload-ladder-sleep-total"
+      run: |
+        counter_file="${{ inputs.sleep-counter-file }}"
+        if [[ -z "$counter_file" ]]; then
+          counter_file="${RUNNER_TEMP}/artifact-upload-ladder-sleep-total"
+        fi
+        ./.github/actions/download-artifact-ladder/sleep-capped.sh \
+          "${{ inputs.retry-delay-seconds }}" \
+          "${{ inputs.max-retry-delay-seconds }}" \
+          "$counter_file"
     - id: upload_primary_3
       name: Upload ${{ inputs.artifact-name }}-r3 (attempt 3)
       if: steps.upload_primary_1.outcome != 'success' && steps.upload_primary_2.outcome != 'success'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,45 +136,23 @@ jobs:
             .maestro-artifacts
           include-hidden-files: true
           if-no-files-found: error
-      - name: Clear partial Maestro web assets artifact before upload retry
-        if: steps.upload_maestro_web_assets_1.outcome == 'failure'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          artifact_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" --paginate -q ".artifacts[] | select(.name==\"maestro-web-assets\") | .id" | head -1)"
-          if [[ -n "$artifact_id" ]]; then
-            gh api --method DELETE "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" || true
-          fi
-          sleep 30
       - name: Upload reusable Maestro web assets (attempt 2)
         if: steps.upload_maestro_web_assets_1.outcome == 'failure'
         id: upload_maestro_web_assets_2
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
-          name: maestro-web-assets
-          overwrite: true
+          name: maestro-web-assets-r2
           path: |
             dist
             .maestro-artifacts
           include-hidden-files: true
           if-no-files-found: error
-      - name: Clear partial Maestro web assets artifact before final upload retry
-        if: steps.upload_maestro_web_assets_1.outcome == 'failure' && steps.upload_maestro_web_assets_2.outcome == 'failure'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          artifact_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" --paginate -q ".artifacts[] | select(.name==\"maestro-web-assets\") | .id" | head -1)"
-          if [[ -n "$artifact_id" ]]; then
-            gh api --method DELETE "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" || true
-          fi
-          sleep 30
       - name: Upload reusable Maestro web assets (attempt 3)
         if: steps.upload_maestro_web_assets_1.outcome == 'failure' && steps.upload_maestro_web_assets_2.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
-          name: maestro-web-assets
-          overwrite: true
+          name: maestro-web-assets-r3
           path: |
             dist
             .maestro-artifacts
@@ -240,14 +218,25 @@ jobs:
         with:
           name: maestro-web-assets
           path: .
-      - name: Wait before final Maestro web assets download
+      - name: Wait before fallback Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         run: sleep 30
-      - name: Download reusable Maestro web assets (attempt 3)
+      - name: Download reusable Maestro web assets (r2 fallback)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        id: download_maestro_web_assets_r2
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: maestro-web-assets
+          name: maestro-web-assets-r2
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        run: sleep 30
+      - name: Download reusable Maestro web assets (r3 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r3
           path: .
       - name: Build Android app
         run: bun scripts/maestro/prepare-android-scenario.mjs "${{ matrix.scenario }}"
@@ -259,42 +248,20 @@ jobs:
           name: maestro-android-app-${{ matrix.scenario }}
           path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
-      - name: Clear partial Android app artifact before upload retry
-        if: steps.upload_android_app_1.outcome == 'failure'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          artifact_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" --paginate -q ".artifacts[] | select(.name==\"maestro-android-app-${{ matrix.scenario }}\") | .id" | head -1)"
-          if [[ -n "$artifact_id" ]]; then
-            gh api --method DELETE "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" || true
-          fi
-          sleep 30
       - name: Upload Android app (attempt 2)
         if: steps.upload_android_app_1.outcome == 'failure'
         id: upload_android_app_2
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
-          name: maestro-android-app-${{ matrix.scenario }}
-          overwrite: true
+          name: maestro-android-app-${{ matrix.scenario }}-r2
           path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
-      - name: Clear partial Android app artifact before final upload retry
-        if: steps.upload_android_app_1.outcome == 'failure' && steps.upload_android_app_2.outcome == 'failure'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          artifact_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" --paginate -q ".artifacts[] | select(.name==\"maestro-android-app-${{ matrix.scenario }}\") | .id" | head -1)"
-          if [[ -n "$artifact_id" ]]; then
-            gh api --method DELETE "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" || true
-          fi
-          sleep 30
       - name: Upload Android app (attempt 3)
         if: steps.upload_android_app_1.outcome == 'failure' && steps.upload_android_app_2.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
-          name: maestro-android-app-${{ matrix.scenario }}
-          overwrite: true
+          name: maestro-android-app-${{ matrix.scenario }}-r3
           path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
 
@@ -338,14 +305,25 @@ jobs:
         with:
           name: maestro-web-assets
           path: .
-      - name: Wait before final Maestro web assets download
+      - name: Wait before fallback Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         run: sleep 30
-      - name: Download reusable Maestro web assets (attempt 3)
+      - name: Download reusable Maestro web assets (r2 fallback)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        id: download_maestro_web_assets_r2
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: maestro-web-assets
+          name: maestro-web-assets-r2
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        run: sleep 30
+      - name: Download reusable Maestro web assets (r3 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r3
           path: .
       - name: Build iOS app
         run: |
@@ -710,14 +688,25 @@ jobs:
         with:
           name: maestro-web-assets
           path: .
-      - name: Wait before final Maestro web assets download
+      - name: Wait before fallback Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         run: sleep 30
-      - name: Download reusable Maestro web assets (attempt 3)
+      - name: Download reusable Maestro web assets (r2 fallback)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        id: download_maestro_web_assets_r2
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: maestro-web-assets
+          name: maestro-web-assets-r2
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        run: sleep 30
+      - name: Download reusable Maestro web assets (r3 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r3
           path: .
       - name: Download Android app (attempt 1)
         id: download_android_app_1
@@ -737,14 +726,25 @@ jobs:
         with:
           name: maestro-android-app-${{ matrix.scenario }}
           path: example-app/android/app/build/outputs/apk/debug
-      - name: Wait before final Android app download
+      - name: Wait before fallback Android app download
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
         run: sleep 30
-      - name: Download Android app (attempt 3)
+      - name: Download Android app (r2 fallback)
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
+        id: download_android_app_r2
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: maestro-android-app-${{ matrix.scenario }}
+          name: maestro-android-app-${{ matrix.scenario }}-r2
+          path: example-app/android/app/build/outputs/apk/debug
+      - name: Wait before final Android app download
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
+        run: sleep 30
+      - name: Download Android app (r3 fallback)
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}-r3
           path: example-app/android/app/build/outputs/apk/debug
       - name: Enable KVM group perms
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -266,6 +266,7 @@ jobs:
     name: Android example app Maestro smoke / ${{ matrix.scenario }}
     env:
       CAPGO_MAESTRO_SUCCESS_MARKER: ${{ github.workspace }}/maestro-android-smoke.pass
+      # Shared 45s retry-sleep budget across both download ladders (not 90s).
       CAPGO_ARTIFACT_LADDER_SLEEP_COUNTER: ${{ github.workspace }}/.artifact-ladder-sleep-total
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,7 @@ jobs:
   maestro_web_assets:
     permissions:
       contents: read
+      # upload-artifact requires actions: write; this job only publishes artifacts.
       actions: write
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -137,6 +138,7 @@ jobs:
   maestro_android_apps:
     permissions:
       contents: read
+      # upload-artifact requires actions: write; download ladder only needs read.
       actions: write
     needs: maestro_web_assets
     timeout-minutes: 10
@@ -191,6 +193,7 @@ jobs:
   maestro_ios_apps:
     permissions:
       contents: read
+      # upload-artifact requires actions: write; download ladder only needs read.
       actions: write
     needs: maestro_web_assets
     timeout-minutes: 10
@@ -257,7 +260,7 @@ jobs:
   maestro_android_example_app:
     permissions:
       contents: read
-      actions: write
+      actions: read
     needs:
       - maestro_web_assets
       - maestro_android_apps
@@ -347,17 +350,11 @@ jobs:
             exit 1
           fi
           echo "Android smoke Maestro scenario '${{ matrix.scenario }}' passed."
-      - name: Upload Maestro artifacts
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: maestro-results-android-${{ matrix.scenario }}
-          path: maestro-results
 
   maestro_ios_example_app:
     permissions:
       contents: read
-      actions: write
+      actions: read
     needs:
       - maestro_web_assets
       - maestro_ios_apps
@@ -413,17 +410,11 @@ jobs:
           CAPGO_MAESTRO_TIMEOUT_SECONDS=300
           MAESTRO_DRIVER_STARTUP_TIMEOUT=90000
           bun run test:maestro:ios:smoke
-      - name: Upload Maestro artifacts
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: maestro-results-ios-${{ matrix.scenario }}
-          path: maestro-results-ios
 
   maestro_ios_live_update:
     permissions:
       contents: read
-      actions: write
+      actions: read
     needs:
       - maestro_web_assets
       - maestro_ios_apps
@@ -479,12 +470,6 @@ jobs:
           CAPGO_MAESTRO_TEST_RETRIES=2 \
           MAESTRO_DRIVER_STARTUP_TIMEOUT=180000 \
           ./scripts/maestro/run-ios-live-update.sh "${{ matrix.scenario }}"
-      - name: Upload live update Maestro artifacts
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: maestro-results-ios-live-update-${{ matrix.scenario }}
-          path: maestro-results-ios-live-update/${{ matrix.scenario }}
 
   web:
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,39 +125,14 @@ jobs:
           install-example: 'true'
       - name: Build reusable Maestro web assets
         run: bun scripts/maestro/build-bundles.mjs all
-      - name: Upload reusable Maestro web assets (attempt 1)
-        id: upload_maestro_web_assets_1
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
+      - name: Upload reusable Maestro web assets
+        uses: ./.github/actions/upload-artifact-ladder
         with:
-          name: maestro-web-assets
+          artifact-name: maestro-web-assets
           path: |
             dist
             .maestro-artifacts
-          include-hidden-files: true
-          if-no-files-found: error
-      - name: Upload reusable Maestro web assets (attempt 2)
-        if: steps.upload_maestro_web_assets_1.outcome == 'failure'
-        id: upload_maestro_web_assets_2
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          name: maestro-web-assets-r2
-          path: |
-            dist
-            .maestro-artifacts
-          include-hidden-files: true
-          if-no-files-found: error
-      - name: Upload reusable Maestro web assets (attempt 3)
-        if: steps.upload_maestro_web_assets_1.outcome == 'failure' && steps.upload_maestro_web_assets_2.outcome == 'failure'
-        uses: actions/upload-artifact@v7
-        with:
-          name: maestro-web-assets-r3
-          path: |
-            dist
-            .maestro-artifacts
-          include-hidden-files: true
-          if-no-files-found: error
+          include-hidden-files: 'true'
 
   maestro_android_apps:
     permissions:
@@ -200,70 +175,18 @@ jobs:
           distribution: 'zulu'
           java-version: '21'
           cache: gradle
-      - name: Download reusable Maestro web assets (attempt 1)
-        id: download_maestro_web_assets_1
-        continue-on-error: true
-        uses: actions/download-artifact@v8
+      - name: Download reusable Maestro web assets
+        uses: ./.github/actions/download-artifact-ladder
         with:
-          name: maestro-web-assets
-          path: .
-      - name: Wait before retrying Maestro web assets download
-        if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        run: sleep 15
-      - name: Download reusable Maestro web assets (attempt 2)
-        if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        id: download_maestro_web_assets_2
-        continue-on-error: true
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-web-assets
-          path: .
-      - name: Wait before fallback Maestro web assets download
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        run: sleep 15
-      - name: Download reusable Maestro web assets (r2 fallback)
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        id: download_maestro_web_assets_r2
-        continue-on-error: true
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-web-assets-r2
-          path: .
-      - name: Wait before final Maestro web assets download
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
-        run: sleep 15
-      - name: Download reusable Maestro web assets (r3 fallback)
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-web-assets-r3
+          artifact-name: maestro-web-assets
           path: .
       - name: Build Android app
         run: bun scripts/maestro/prepare-android-scenario.mjs "${{ matrix.scenario }}"
-      - name: Upload Android app (attempt 1)
-        id: upload_android_app_1
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
+      - name: Upload Android app
+        uses: ./.github/actions/upload-artifact-ladder
         with:
-          name: maestro-android-app-${{ matrix.scenario }}
+          artifact-name: maestro-android-app-${{ matrix.scenario }}
           path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
-          if-no-files-found: error
-      - name: Upload Android app (attempt 2)
-        if: steps.upload_android_app_1.outcome == 'failure'
-        id: upload_android_app_2
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          name: maestro-android-app-${{ matrix.scenario }}-r2
-          path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
-          if-no-files-found: error
-      - name: Upload Android app (attempt 3)
-        if: steps.upload_android_app_1.outcome == 'failure' && steps.upload_android_app_2.outcome == 'failure'
-        uses: actions/upload-artifact@v7
-        with:
-          name: maestro-android-app-${{ matrix.scenario }}-r3
-          path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
-          if-no-files-found: error
 
   maestro_ios_apps:
     permissions:
@@ -287,43 +210,10 @@ jobs:
             node_modules
             example-app/node_modules
           install-example: 'true'
-      - name: Download reusable Maestro web assets (attempt 1)
-        id: download_maestro_web_assets_1
-        continue-on-error: true
-        uses: actions/download-artifact@v8
+      - name: Download reusable Maestro web assets
+        uses: ./.github/actions/download-artifact-ladder
         with:
-          name: maestro-web-assets
-          path: .
-      - name: Wait before retrying Maestro web assets download
-        if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        run: sleep 15
-      - name: Download reusable Maestro web assets (attempt 2)
-        if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        id: download_maestro_web_assets_2
-        continue-on-error: true
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-web-assets
-          path: .
-      - name: Wait before fallback Maestro web assets download
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        run: sleep 15
-      - name: Download reusable Maestro web assets (r2 fallback)
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        id: download_maestro_web_assets_r2
-        continue-on-error: true
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-web-assets-r2
-          path: .
-      - name: Wait before final Maestro web assets download
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
-        run: sleep 15
-      - name: Download reusable Maestro web assets (r3 fallback)
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-web-assets-r3
+          artifact-name: maestro-web-assets
           path: .
       - name: Build iOS app
         run: |
@@ -359,11 +249,10 @@ jobs:
             ditto "$derived_data_path/Build/Products/Debug-iphonesimulator/App.app" "$app_artifact_path/App.app"
           done
       - name: Upload iOS apps
-        uses: actions/upload-artifact@v7
+        uses: ./.github/actions/upload-artifact-ladder
         with:
-          name: maestro-ios-apps
+          artifact-name: maestro-ios-apps
           path: ${{ runner.temp }}/maestro-ios-apps
-          if-no-files-found: error
 
   maestro_android_example_app:
     permissions:
@@ -377,6 +266,7 @@ jobs:
     name: Android example app Maestro smoke / ${{ matrix.scenario }}
     env:
       CAPGO_MAESTRO_SUCCESS_MARKER: ${{ github.workspace }}/maestro-android-smoke.pass
+      CAPGO_ARTIFACT_LADDER_SLEEP_COUNTER: ${{ runner.temp }}/artifact-ladder-sleep-total
     strategy:
       fail-fast: false
       matrix:
@@ -408,82 +298,20 @@ jobs:
         uses: ./.github/actions/setup-maestro
         with:
           maestro-version: ${{ env.MAESTRO_VERSION }}
-      - name: Download reusable Maestro web assets (attempt 1)
-        id: download_maestro_web_assets_1
-        continue-on-error: true
-        uses: actions/download-artifact@v8
+      - name: Download reusable Maestro web assets
+        uses: ./.github/actions/download-artifact-ladder
         with:
-          name: maestro-web-assets
+          artifact-name: maestro-web-assets
           path: .
-      - name: Wait before retrying Maestro web assets download
-        if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        run: sleep 15
-      - name: Download reusable Maestro web assets (attempt 2)
-        if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        id: download_maestro_web_assets_2
-        continue-on-error: true
-        uses: actions/download-artifact@v8
+          max-retry-delay-seconds: '45'
+          sleep-counter-file: ${{ env.CAPGO_ARTIFACT_LADDER_SLEEP_COUNTER }}
+      - name: Download Android app
+        uses: ./.github/actions/download-artifact-ladder
         with:
-          name: maestro-web-assets
-          path: .
-      - name: Wait before fallback Maestro web assets download
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        run: sleep 15
-      - name: Download reusable Maestro web assets (r2 fallback)
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        id: download_maestro_web_assets_r2
-        continue-on-error: true
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-web-assets-r2
-          path: .
-      - name: Wait before final Maestro web assets download
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
-        run: sleep 15
-      - name: Download reusable Maestro web assets (r3 fallback)
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-web-assets-r3
-          path: .
-      - name: Download Android app (attempt 1)
-        id: download_android_app_1
-        continue-on-error: true
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-android-app-${{ matrix.scenario }}
+          artifact-name: maestro-android-app-${{ matrix.scenario }}
           path: example-app/android/app/build/outputs/apk/debug
-      - name: Wait before retrying Android app download
-        if: steps.download_android_app_1.outcome == 'failure'
-        run: sleep 15
-      - name: Download Android app (attempt 2)
-        if: steps.download_android_app_1.outcome == 'failure'
-        id: download_android_app_2
-        continue-on-error: true
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-android-app-${{ matrix.scenario }}
-          path: example-app/android/app/build/outputs/apk/debug
-      - name: Wait before fallback Android app download
-        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
-        run: sleep 15
-      - name: Download Android app (r2 fallback)
-        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
-        id: download_android_app_r2
-        continue-on-error: true
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-android-app-${{ matrix.scenario }}-r2
-          path: example-app/android/app/build/outputs/apk/debug
-      - name: Wait before final Android app download
-        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
-        run: sleep 15
-      - name: Download Android app (r3 fallback)
-        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-android-app-${{ matrix.scenario }}-r3
-          path: example-app/android/app/build/outputs/apk/debug
+          max-retry-delay-seconds: '45'
+          sleep-counter-file: ${{ env.CAPGO_ARTIFACT_LADDER_SLEEP_COUNTER }}
       - name: Enable KVM group perms
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -562,48 +390,15 @@ jobs:
         uses: ./.github/actions/setup-maestro
         with:
           maestro-version: ${{ env.MAESTRO_VERSION }}
-      - name: Download reusable Maestro web assets (attempt 1)
-        id: download_maestro_web_assets_1
-        continue-on-error: true
-        uses: actions/download-artifact@v8
+      - name: Download reusable Maestro web assets
+        uses: ./.github/actions/download-artifact-ladder
         with:
-          name: maestro-web-assets
-          path: .
-      - name: Wait before retrying Maestro web assets download
-        if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        run: sleep 15
-      - name: Download reusable Maestro web assets (attempt 2)
-        if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        id: download_maestro_web_assets_2
-        continue-on-error: true
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-web-assets
-          path: .
-      - name: Wait before fallback Maestro web assets download
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        run: sleep 15
-      - name: Download reusable Maestro web assets (r2 fallback)
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        id: download_maestro_web_assets_r2
-        continue-on-error: true
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-web-assets-r2
-          path: .
-      - name: Wait before final Maestro web assets download
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
-        run: sleep 15
-      - name: Download reusable Maestro web assets (r3 fallback)
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-web-assets-r3
+          artifact-name: maestro-web-assets
           path: .
       - name: Download iOS app
-        uses: actions/download-artifact@v8
+        uses: ./.github/actions/download-artifact-ladder
         with:
-          name: maestro-ios-apps
+          artifact-name: maestro-ios-apps
           path: maestro-ios-apps
       - name: Run Maestro smoke tests
         run: >-
@@ -661,48 +456,15 @@ jobs:
         uses: ./.github/actions/setup-maestro
         with:
           maestro-version: ${{ env.MAESTRO_VERSION }}
-      - name: Download reusable Maestro web assets (attempt 1)
-        id: download_maestro_web_assets_1
-        continue-on-error: true
-        uses: actions/download-artifact@v8
+      - name: Download reusable Maestro web assets
+        uses: ./.github/actions/download-artifact-ladder
         with:
-          name: maestro-web-assets
-          path: .
-      - name: Wait before retrying Maestro web assets download
-        if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        run: sleep 15
-      - name: Download reusable Maestro web assets (attempt 2)
-        if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        id: download_maestro_web_assets_2
-        continue-on-error: true
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-web-assets
-          path: .
-      - name: Wait before fallback Maestro web assets download
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        run: sleep 15
-      - name: Download reusable Maestro web assets (r2 fallback)
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        id: download_maestro_web_assets_r2
-        continue-on-error: true
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-web-assets-r2
-          path: .
-      - name: Wait before final Maestro web assets download
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
-        run: sleep 15
-      - name: Download reusable Maestro web assets (r3 fallback)
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-web-assets-r3
+          artifact-name: maestro-web-assets
           path: .
       - name: Download iOS app
-        uses: actions/download-artifact@v8
+        uses: ./.github/actions/download-artifact-ladder
         with:
-          name: maestro-ios-apps
+          artifact-name: maestro-ios-apps
           path: maestro-ios-apps
       - name: Run live update Maestro flows
         run: |
@@ -802,81 +564,15 @@ jobs:
         uses: ./.github/actions/setup-maestro
         with:
           maestro-version: ${{ env.MAESTRO_VERSION }}
-      - name: Download reusable Maestro web assets (attempt 1)
-        id: download_maestro_web_assets_1
-        continue-on-error: true
-        uses: actions/download-artifact@v8
+      - name: Download reusable Maestro web assets
+        uses: ./.github/actions/download-artifact-ladder
         with:
-          name: maestro-web-assets
+          artifact-name: maestro-web-assets
           path: .
-      - name: Wait before retrying Maestro web assets download
-        if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        run: sleep 15
-      - name: Download reusable Maestro web assets (attempt 2)
-        if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        id: download_maestro_web_assets_2
-        continue-on-error: true
-        uses: actions/download-artifact@v8
+      - name: Download Android app
+        uses: ./.github/actions/download-artifact-ladder
         with:
-          name: maestro-web-assets
-          path: .
-      - name: Wait before fallback Maestro web assets download
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        run: sleep 15
-      - name: Download reusable Maestro web assets (r2 fallback)
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        id: download_maestro_web_assets_r2
-        continue-on-error: true
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-web-assets-r2
-          path: .
-      - name: Wait before final Maestro web assets download
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
-        run: sleep 15
-      - name: Download reusable Maestro web assets (r3 fallback)
-        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-web-assets-r3
-          path: .
-      - name: Download Android app (attempt 1)
-        id: download_android_app_1
-        continue-on-error: true
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-android-app-${{ matrix.scenario }}
-          path: example-app/android/app/build/outputs/apk/debug
-      - name: Wait before retrying Android app download
-        if: steps.download_android_app_1.outcome == 'failure'
-        run: sleep 15
-      - name: Download Android app (attempt 2)
-        if: steps.download_android_app_1.outcome == 'failure'
-        id: download_android_app_2
-        continue-on-error: true
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-android-app-${{ matrix.scenario }}
-          path: example-app/android/app/build/outputs/apk/debug
-      - name: Wait before fallback Android app download
-        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
-        run: sleep 15
-      - name: Download Android app (r2 fallback)
-        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
-        id: download_android_app_r2
-        continue-on-error: true
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-android-app-${{ matrix.scenario }}-r2
-          path: example-app/android/app/build/outputs/apk/debug
-      - name: Wait before final Android app download
-        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
-        run: sleep 15
-      - name: Download Android app (r3 fallback)
-        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
-        uses: actions/download-artifact@v8
-        with:
-          name: maestro-android-app-${{ matrix.scenario }}-r3
+          artifact-name: maestro-android-app-${{ matrix.scenario }}
           path: example-app/android/app/build/outputs/apk/debug
       - name: Enable KVM group perms
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,7 +209,7 @@ jobs:
           path: .
       - name: Wait before retrying Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download reusable Maestro web assets (attempt 2)
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
         id: download_maestro_web_assets_2
@@ -220,7 +220,7 @@ jobs:
           path: .
       - name: Wait before fallback Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download reusable Maestro web assets (r2 fallback)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         id: download_maestro_web_assets_r2
@@ -231,7 +231,7 @@ jobs:
           path: .
       - name: Wait before final Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download reusable Maestro web assets (r3 fallback)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
         uses: actions/download-artifact@v8
@@ -296,7 +296,7 @@ jobs:
           path: .
       - name: Wait before retrying Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download reusable Maestro web assets (attempt 2)
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
         id: download_maestro_web_assets_2
@@ -307,7 +307,7 @@ jobs:
           path: .
       - name: Wait before fallback Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download reusable Maestro web assets (r2 fallback)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         id: download_maestro_web_assets_r2
@@ -318,7 +318,7 @@ jobs:
           path: .
       - name: Wait before final Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download reusable Maestro web assets (r3 fallback)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
         uses: actions/download-artifact@v8
@@ -408,15 +408,81 @@ jobs:
         uses: ./.github/actions/setup-maestro
         with:
           maestro-version: ${{ env.MAESTRO_VERSION }}
-      - name: Download reusable Maestro web assets
+      - name: Download reusable Maestro web assets (attempt 1)
+        id: download_maestro_web_assets_1
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets
           path: .
-      - name: Download Android app
+      - name: Wait before retrying Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 2)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        id: download_maestro_web_assets_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before fallback Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (r2 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        id: download_maestro_web_assets_r2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r2
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (r3 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r3
+          path: .
+      - name: Download Android app (attempt 1)
+        id: download_android_app_1
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: maestro-android-app-${{ matrix.scenario }}
+          path: example-app/android/app/build/outputs/apk/debug
+      - name: Wait before retrying Android app download
+        if: steps.download_android_app_1.outcome == 'failure'
+        run: sleep 15
+      - name: Download Android app (attempt 2)
+        if: steps.download_android_app_1.outcome == 'failure'
+        id: download_android_app_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}
+          path: example-app/android/app/build/outputs/apk/debug
+      - name: Wait before fallback Android app download
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
+        run: sleep 15
+      - name: Download Android app (r2 fallback)
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
+        id: download_android_app_r2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}-r2
+          path: example-app/android/app/build/outputs/apk/debug
+      - name: Wait before final Android app download
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
+        run: sleep 15
+      - name: Download Android app (r3 fallback)
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}-r3
           path: example-app/android/app/build/outputs/apk/debug
       - name: Enable KVM group perms
         run: |
@@ -496,10 +562,43 @@ jobs:
         uses: ./.github/actions/setup-maestro
         with:
           maestro-version: ${{ env.MAESTRO_VERSION }}
-      - name: Download reusable Maestro web assets
+      - name: Download reusable Maestro web assets (attempt 1)
+        id: download_maestro_web_assets_1
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets
+          path: .
+      - name: Wait before retrying Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 2)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        id: download_maestro_web_assets_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before fallback Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (r2 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        id: download_maestro_web_assets_r2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r2
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (r3 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r3
           path: .
       - name: Download iOS app
         uses: actions/download-artifact@v8
@@ -562,10 +661,43 @@ jobs:
         uses: ./.github/actions/setup-maestro
         with:
           maestro-version: ${{ env.MAESTRO_VERSION }}
-      - name: Download reusable Maestro web assets
+      - name: Download reusable Maestro web assets (attempt 1)
+        id: download_maestro_web_assets_1
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets
+          path: .
+      - name: Wait before retrying Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 2)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        id: download_maestro_web_assets_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before fallback Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (r2 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        id: download_maestro_web_assets_r2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r2
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (r3 fallback)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets-r3
           path: .
       - name: Download iOS app
         uses: actions/download-artifact@v8
@@ -679,7 +811,7 @@ jobs:
           path: .
       - name: Wait before retrying Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download reusable Maestro web assets (attempt 2)
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
         id: download_maestro_web_assets_2
@@ -690,7 +822,7 @@ jobs:
           path: .
       - name: Wait before fallback Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download reusable Maestro web assets (r2 fallback)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         id: download_maestro_web_assets_r2
@@ -701,7 +833,7 @@ jobs:
           path: .
       - name: Wait before final Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download reusable Maestro web assets (r3 fallback)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure' && steps.download_maestro_web_assets_r2.outcome == 'failure'
         uses: actions/download-artifact@v8
@@ -717,7 +849,7 @@ jobs:
           path: example-app/android/app/build/outputs/apk/debug
       - name: Wait before retrying Android app download
         if: steps.download_android_app_1.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download Android app (attempt 2)
         if: steps.download_android_app_1.outcome == 'failure'
         id: download_android_app_2
@@ -728,7 +860,7 @@ jobs:
           path: example-app/android/app/build/outputs/apk/debug
       - name: Wait before fallback Android app download
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download Android app (r2 fallback)
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
         id: download_android_app_r2
@@ -739,7 +871,7 @@ jobs:
           path: example-app/android/app/build/outputs/apk/debug
       - name: Wait before final Android app download
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
-        run: sleep 30
+        run: sleep 15
       - name: Download Android app (r3 fallback)
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure' && steps.download_android_app_r2.outcome == 'failure'
         uses: actions/download-artifact@v8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,7 @@ jobs:
   maestro_web_assets:
     permissions:
       contents: read
+      actions: write
     timeout-minutes: 10
     runs-on: ubuntu-latest
     name: Build Maestro web assets
@@ -135,6 +136,16 @@ jobs:
             .maestro-artifacts
           include-hidden-files: true
           if-no-files-found: error
+      - name: Clear partial Maestro web assets artifact before upload retry
+        if: steps.upload_maestro_web_assets_1.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" --paginate -q ".artifacts[] | select(.name==\"maestro-web-assets\") | .id" | head -1)"
+          if [[ -n "$artifact_id" ]]; then
+            gh api --method DELETE "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" || true
+          fi
+          sleep 30
       - name: Upload reusable Maestro web assets (attempt 2)
         if: steps.upload_maestro_web_assets_1.outcome == 'failure'
         id: upload_maestro_web_assets_2
@@ -148,6 +159,16 @@ jobs:
             .maestro-artifacts
           include-hidden-files: true
           if-no-files-found: error
+      - name: Clear partial Maestro web assets artifact before final upload retry
+        if: steps.upload_maestro_web_assets_1.outcome == 'failure' && steps.upload_maestro_web_assets_2.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" --paginate -q ".artifacts[] | select(.name==\"maestro-web-assets\") | .id" | head -1)"
+          if [[ -n "$artifact_id" ]]; then
+            gh api --method DELETE "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" || true
+          fi
+          sleep 30
       - name: Upload reusable Maestro web assets (attempt 3)
         if: steps.upload_maestro_web_assets_1.outcome == 'failure' && steps.upload_maestro_web_assets_2.outcome == 'failure'
         uses: actions/upload-artifact@v7
@@ -163,6 +184,7 @@ jobs:
   maestro_android_apps:
     permissions:
       contents: read
+      actions: write
     needs: maestro_web_assets
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -209,7 +231,7 @@ jobs:
           path: .
       - name: Wait before retrying Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        run: sleep 15
+        run: sleep 30
       - name: Download reusable Maestro web assets (attempt 2)
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
         id: download_maestro_web_assets_2
@@ -220,7 +242,7 @@ jobs:
           path: .
       - name: Wait before final Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        run: sleep 15
+        run: sleep 30
       - name: Download reusable Maestro web assets (attempt 3)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         uses: actions/download-artifact@v8
@@ -237,6 +259,16 @@ jobs:
           name: maestro-android-app-${{ matrix.scenario }}
           path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
+      - name: Clear partial Android app artifact before upload retry
+        if: steps.upload_android_app_1.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" --paginate -q ".artifacts[] | select(.name==\"maestro-android-app-${{ matrix.scenario }}\") | .id" | head -1)"
+          if [[ -n "$artifact_id" ]]; then
+            gh api --method DELETE "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" || true
+          fi
+          sleep 30
       - name: Upload Android app (attempt 2)
         if: steps.upload_android_app_1.outcome == 'failure'
         id: upload_android_app_2
@@ -247,6 +279,16 @@ jobs:
           overwrite: true
           path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
+      - name: Clear partial Android app artifact before final upload retry
+        if: steps.upload_android_app_1.outcome == 'failure' && steps.upload_android_app_2.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" --paginate -q ".artifacts[] | select(.name==\"maestro-android-app-${{ matrix.scenario }}\") | .id" | head -1)"
+          if [[ -n "$artifact_id" ]]; then
+            gh api --method DELETE "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" || true
+          fi
+          sleep 30
       - name: Upload Android app (attempt 3)
         if: steps.upload_android_app_1.outcome == 'failure' && steps.upload_android_app_2.outcome == 'failure'
         uses: actions/upload-artifact@v7
@@ -259,6 +301,7 @@ jobs:
   maestro_ios_apps:
     permissions:
       contents: read
+      actions: write
     needs: maestro_web_assets
     timeout-minutes: 10
     runs-on: macOS-latest
@@ -286,7 +329,7 @@ jobs:
           path: .
       - name: Wait before retrying Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        run: sleep 15
+        run: sleep 30
       - name: Download reusable Maestro web assets (attempt 2)
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
         id: download_maestro_web_assets_2
@@ -297,7 +340,7 @@ jobs:
           path: .
       - name: Wait before final Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        run: sleep 15
+        run: sleep 30
       - name: Download reusable Maestro web assets (attempt 3)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         uses: actions/download-artifact@v8
@@ -347,6 +390,7 @@ jobs:
   maestro_android_example_app:
     permissions:
       contents: read
+      actions: write
     needs:
       - maestro_web_assets
       - maestro_android_apps
@@ -440,6 +484,7 @@ jobs:
   maestro_ios_example_app:
     permissions:
       contents: read
+      actions: write
     needs:
       - maestro_web_assets
       - maestro_ios_apps
@@ -505,6 +550,7 @@ jobs:
   maestro_ios_live_update:
     permissions:
       contents: read
+      actions: write
     needs:
       - maestro_web_assets
       - maestro_ios_apps
@@ -602,6 +648,7 @@ jobs:
   maestro_android_scenarios:
     permissions:
       contents: read
+      actions: read
     needs:
       - maestro_web_assets
       - maestro_android_apps
@@ -654,7 +701,7 @@ jobs:
           path: .
       - name: Wait before retrying Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
-        run: sleep 15
+        run: sleep 30
       - name: Download reusable Maestro web assets (attempt 2)
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
         id: download_maestro_web_assets_2
@@ -665,7 +712,7 @@ jobs:
           path: .
       - name: Wait before final Maestro web assets download
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
-        run: sleep 15
+        run: sleep 30
       - name: Download reusable Maestro web assets (attempt 3)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         uses: actions/download-artifact@v8
@@ -681,7 +728,7 @@ jobs:
           path: example-app/android/app/build/outputs/apk/debug
       - name: Wait before retrying Android app download
         if: steps.download_android_app_1.outcome == 'failure'
-        run: sleep 15
+        run: sleep 30
       - name: Download Android app (attempt 2)
         if: steps.download_android_app_1.outcome == 'failure'
         id: download_android_app_2
@@ -692,7 +739,7 @@ jobs:
           path: example-app/android/app/build/outputs/apk/debug
       - name: Wait before final Android app download
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
-        run: sleep 15
+        run: sleep 30
       - name: Download Android app (attempt 3)
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
         uses: actions/download-artifact@v8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,7 @@ jobs:
   maestro_web_assets:
     permissions:
       contents: read
+      actions: write
     timeout-minutes: 10
     runs-on: ubuntu-latest
     name: Build Maestro web assets
@@ -137,6 +138,7 @@ jobs:
   maestro_android_apps:
     permissions:
       contents: read
+      actions: write
     needs: maestro_web_assets
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -191,6 +193,7 @@ jobs:
   maestro_ios_apps:
     permissions:
       contents: read
+      actions: write
     needs: maestro_web_assets
     timeout-minutes: 10
     runs-on: macOS-latest
@@ -257,6 +260,7 @@ jobs:
   maestro_android_example_app:
     permissions:
       contents: read
+      actions: write
     needs:
       - maestro_web_assets
       - maestro_android_apps
@@ -350,6 +354,7 @@ jobs:
   maestro_ios_example_app:
     permissions:
       contents: read
+      actions: write
     needs:
       - maestro_web_assets
       - maestro_ios_apps
@@ -415,6 +420,7 @@ jobs:
   maestro_ios_live_update:
     permissions:
       contents: read
+      actions: write
     needs:
       - maestro_web_assets
       - maestro_ios_apps
@@ -512,6 +518,7 @@ jobs:
   maestro_android_scenarios:
     permissions:
       contents: read
+      actions: read
     needs:
       - maestro_web_assets
       - maestro_android_apps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -260,7 +260,6 @@ jobs:
   maestro_android_example_app:
     permissions:
       contents: read
-      actions: read
     needs:
       - maestro_web_assets
       - maestro_android_apps
@@ -354,7 +353,6 @@ jobs:
   maestro_ios_example_app:
     permissions:
       contents: read
-      actions: read
     needs:
       - maestro_web_assets
       - maestro_ios_apps
@@ -414,7 +412,6 @@ jobs:
   maestro_ios_live_update:
     permissions:
       contents: read
-      actions: read
     needs:
       - maestro_web_assets
       - maestro_ios_apps
@@ -506,7 +503,6 @@ jobs:
   maestro_android_scenarios:
     permissions:
       contents: read
-      actions: read
     needs:
       - maestro_web_assets
       - maestro_android_apps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,6 @@ jobs:
   maestro_web_assets:
     permissions:
       contents: read
-      actions: write
     timeout-minutes: 10
     runs-on: ubuntu-latest
     name: Build Maestro web assets
@@ -143,6 +142,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: maestro-web-assets
+          overwrite: true
           path: |
             dist
             .maestro-artifacts
@@ -153,6 +153,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: maestro-web-assets
+          overwrite: true
           path: |
             dist
             .maestro-artifacts
@@ -162,7 +163,6 @@ jobs:
   maestro_android_apps:
     permissions:
       contents: read
-      actions: write
     needs: maestro_web_assets
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -200,7 +200,29 @@ jobs:
           distribution: 'zulu'
           java-version: '21'
           cache: gradle
-      - name: Download reusable Maestro web assets
+      - name: Download reusable Maestro web assets (attempt 1)
+        id: download_maestro_web_assets_1
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before retrying Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 2)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        id: download_maestro_web_assets_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 3)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets
@@ -222,6 +244,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: maestro-android-app-${{ matrix.scenario }}
+          overwrite: true
           path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
       - name: Upload Android app (attempt 3)
@@ -229,13 +252,13 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: maestro-android-app-${{ matrix.scenario }}
+          overwrite: true
           path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
 
   maestro_ios_apps:
     permissions:
       contents: read
-      actions: write
     needs: maestro_web_assets
     timeout-minutes: 10
     runs-on: macOS-latest
@@ -254,7 +277,29 @@ jobs:
             node_modules
             example-app/node_modules
           install-example: 'true'
-      - name: Download reusable Maestro web assets
+      - name: Download reusable Maestro web assets (attempt 1)
+        id: download_maestro_web_assets_1
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before retrying Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 2)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        id: download_maestro_web_assets_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 3)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets
@@ -302,7 +347,6 @@ jobs:
   maestro_android_example_app:
     permissions:
       contents: read
-      actions: write
     needs:
       - maestro_web_assets
       - maestro_android_apps
@@ -396,7 +440,6 @@ jobs:
   maestro_ios_example_app:
     permissions:
       contents: read
-      actions: write
     needs:
       - maestro_web_assets
       - maestro_ios_apps
@@ -462,7 +505,6 @@ jobs:
   maestro_ios_live_update:
     permissions:
       contents: read
-      actions: write
     needs:
       - maestro_web_assets
       - maestro_ios_apps
@@ -560,7 +602,6 @@ jobs:
   maestro_android_scenarios:
     permissions:
       contents: read
-      actions: write
     needs:
       - maestro_web_assets
       - maestro_android_apps
@@ -611,6 +652,9 @@ jobs:
         with:
           name: maestro-web-assets
           path: .
+      - name: Wait before retrying Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        run: sleep 15
       - name: Download reusable Maestro web assets (attempt 2)
         if: steps.download_maestro_web_assets_1.outcome == 'failure'
         id: download_maestro_web_assets_2
@@ -619,6 +663,9 @@ jobs:
         with:
           name: maestro-web-assets
           path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        run: sleep 15
       - name: Download reusable Maestro web assets (attempt 3)
         if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         uses: actions/download-artifact@v8
@@ -632,6 +679,9 @@ jobs:
         with:
           name: maestro-android-app-${{ matrix.scenario }}
           path: example-app/android/app/build/outputs/apk/debug
+      - name: Wait before retrying Android app download
+        if: steps.download_android_app_1.outcome == 'failure'
+        run: sleep 15
       - name: Download Android app (attempt 2)
         if: steps.download_android_app_1.outcome == 'failure'
         id: download_android_app_2
@@ -640,6 +690,9 @@ jobs:
         with:
           name: maestro-android-app-${{ matrix.scenario }}
           path: example-app/android/app/build/outputs/apk/debug
+      - name: Wait before final Android app download
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
+        run: sleep 15
       - name: Download Android app (attempt 3)
         if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
         uses: actions/download-artifact@v8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -266,7 +266,7 @@ jobs:
     name: Android example app Maestro smoke / ${{ matrix.scenario }}
     env:
       CAPGO_MAESTRO_SUCCESS_MARKER: ${{ github.workspace }}/maestro-android-smoke.pass
-      CAPGO_ARTIFACT_LADDER_SLEEP_COUNTER: ${{ runner.temp }}/artifact-ladder-sleep-total
+      CAPGO_ARTIFACT_LADDER_SLEEP_COUNTER: ${{ github.workspace }}/.artifact-ladder-sleep-total
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,31 @@ jobs:
           install-example: 'true'
       - name: Build reusable Maestro web assets
         run: bun scripts/maestro/build-bundles.mjs all
-      - name: Upload reusable Maestro web assets
+      - name: Upload reusable Maestro web assets (attempt 1)
+        id: upload_maestro_web_assets_1
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: maestro-web-assets
+          path: |
+            dist
+            .maestro-artifacts
+          include-hidden-files: true
+          if-no-files-found: error
+      - name: Upload reusable Maestro web assets (attempt 2)
+        if: steps.upload_maestro_web_assets_1.outcome == 'failure'
+        id: upload_maestro_web_assets_2
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: maestro-web-assets
+          path: |
+            dist
+            .maestro-artifacts
+          include-hidden-files: true
+          if-no-files-found: error
+      - name: Upload reusable Maestro web assets (attempt 3)
+        if: steps.upload_maestro_web_assets_1.outcome == 'failure' && steps.upload_maestro_web_assets_2.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
           name: maestro-web-assets
@@ -183,7 +207,25 @@ jobs:
           path: .
       - name: Build Android app
         run: bun scripts/maestro/prepare-android-scenario.mjs "${{ matrix.scenario }}"
-      - name: Upload Android app
+      - name: Upload Android app (attempt 1)
+        id: upload_android_app_1
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}
+          path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
+      - name: Upload Android app (attempt 2)
+        if: steps.upload_android_app_1.outcome == 'failure'
+        id: upload_android_app_2
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}
+          path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
+      - name: Upload Android app (attempt 3)
+        if: steps.upload_android_app_1.outcome == 'failure' && steps.upload_android_app_2.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
           name: maestro-android-app-${{ matrix.scenario }}
@@ -518,7 +560,7 @@ jobs:
   maestro_android_scenarios:
     permissions:
       contents: read
-      actions: read
+      actions: write
     needs:
       - maestro_web_assets
       - maestro_android_apps
@@ -562,12 +604,44 @@ jobs:
         uses: ./.github/actions/setup-maestro
         with:
           maestro-version: ${{ env.MAESTRO_VERSION }}
-      - name: Download reusable Maestro web assets
+      - name: Download reusable Maestro web assets (attempt 1)
+        id: download_maestro_web_assets_1
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets
           path: .
-      - name: Download Android app
+      - name: Download reusable Maestro web assets (attempt 2)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        id: download_maestro_web_assets_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Download reusable Maestro web assets (attempt 3)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Download Android app (attempt 1)
+        id: download_android_app_1
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}
+          path: example-app/android/app/build/outputs/apk/debug
+      - name: Download Android app (attempt 2)
+        if: steps.download_android_app_1.outcome == 'failure'
+        id: download_android_app_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}
+          path: example-app/android/app/build/outputs/apk/debug
+      - name: Download Android app (attempt 3)
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: maestro-android-app-${{ matrix.scenario }}

--- a/CapgoCapacitorUpdater.podspec
+++ b/CapgoCapacitorUpdater.podspec
@@ -14,7 +14,6 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
   s.dependency 'ZIPFoundation', '~> 0.9'
-  s.dependency 'Alamofire', '5.10.2'
   s.dependency 'Version', '0.8.0'
   s.swift_version = '5.1'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,6 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
-        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.12.0")),
         .package(url: "https://github.com/weichsel/ZIPFoundation.git", from: "0.9.20"),
         .package(url: "https://github.com/mrackwitz/Version.git", exact: "0.8.0")
     ],
@@ -22,7 +21,6 @@ let package = Package(
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
                 .product(name: "ZIPFoundation", package: "ZIPFoundation"),
-                .product(name: "Alamofire", package: "Alamofire"),
                 .product(name: "Version", package: "Version")
             ],
             path: "ios/Sources/CapacitorUpdaterPlugin"),

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -192,13 +192,21 @@ import UIKit
         }
     }
 
+    private func shouldPreserveDownloadedTempFile(error: Error?, statusCode: Int?) -> Bool {
+        if Self.shouldPreserveDownloadTempFile(error: error) {
+            return true
+        }
+        return error == nil && isSuccessfulDownloadStatus(statusCode)
+    }
+
     private func partialFileURL(fromResumeData resumeData: Data, destination: URL) -> URL? {
         let waitTimeout: TimeInterval = 5
         let semaphore = DispatchSemaphore(value: 0)
         var preservedURL: URL?
-        let task = self.urlSession.downloadTask(withResumeData: resumeData) { location, _, error in
+        let task = self.urlSession.downloadTask(withResumeData: resumeData) { location, response, error in
+            let statusCode = (response as? HTTPURLResponse)?.statusCode
             if let location {
-                if error == nil || Self.shouldPreserveDownloadTempFile(error: error) {
+                if self.shouldPreserveDownloadedTempFile(error: error, statusCode: statusCode) {
                     preservedURL = self.preserveDownloadedFile(at: location, to: destination)
                 } else {
                     try? FileManager.default.removeItem(at: location)
@@ -340,10 +348,13 @@ import UIKit
         task.resume()
 
         if semaphore.wait(timeout: .now() + waitTimeout) == .timedOut {
+            let resumeDataSemaphore = DispatchSemaphore(value: 0)
             task.cancel(byProducingResumeData: { resumeData in
                 resumeDataFromCancel = resumeData
+                resumeDataSemaphore.signal()
             })
             _ = semaphore.wait(timeout: .now() + 5)
+            _ = resumeDataSemaphore.wait(timeout: .now() + 1)
             if tempFileURL == nil, let resumeData = resumeDataFromCancel {
                 tempFileURL = partialFileURL(fromResumeData: resumeData, destination: temporaryDownloadURL)
             }

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -255,6 +255,13 @@ import UIKit
         return RequestResult(data: responseData, response: httpResponse, error: requestError, timedOut: false)
     }
 
+    private func isSuccessfulDownloadStatus(_ statusCode: Int?) -> Bool {
+        guard let statusCode else {
+            return false
+        }
+        return statusCode >= 200 && statusCode < 300
+    }
+
     private func performDownloadRequest(_ request: URLRequest, label: String) -> DownloadRequestResult {
         let waitTimeout = max(self.timeout + 5, 10)
         let semaphore = DispatchSemaphore(value: 0)
@@ -263,20 +270,26 @@ import UIKit
         var requestError: Error?
         let temporaryDownloadURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let task = self.urlSession.downloadTask(with: request) { location, response, error in
-            if let location {
-                do {
-                    if FileManager.default.fileExists(atPath: temporaryDownloadURL.path) {
-                        try FileManager.default.removeItem(at: temporaryDownloadURL)
-                    }
-                    try FileManager.default.moveItem(at: location, to: temporaryDownloadURL)
-                    tempFileURL = temporaryDownloadURL
-                } catch {
-                    requestError = error
-                }
-            }
             httpResponse = response as? HTTPURLResponse
-            if requestError == nil {
+            if let error {
                 requestError = error
+            }
+
+            if let location {
+                if requestError == nil && isSuccessfulDownloadStatus(httpResponse?.statusCode) {
+                    do {
+                        if FileManager.default.fileExists(atPath: temporaryDownloadURL.path) {
+                            try FileManager.default.removeItem(at: temporaryDownloadURL)
+                        }
+                        try FileManager.default.moveItem(at: location, to: temporaryDownloadURL)
+                        tempFileURL = temporaryDownloadURL
+                    } catch {
+                        requestError = error
+                        try? FileManager.default.removeItem(at: location)
+                    }
+                } else {
+                    try? FileManager.default.removeItem(at: location)
+                }
             }
             semaphore.signal()
         }

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -247,6 +247,7 @@ import UIKit
 
         if semaphore.wait(timeout: .now() + waitTimeout) == .timedOut {
             task.cancel()
+            _ = semaphore.wait(timeout: .now() + 5)
             logger.error("\(label) timed out after \(Int(waitTimeout))s")
             return RequestResult(data: responseData, response: httpResponse, error: requestError, timedOut: true)
         }
@@ -283,6 +284,7 @@ import UIKit
 
         if semaphore.wait(timeout: .now() + waitTimeout) == .timedOut {
             task.cancel()
+            _ = semaphore.wait(timeout: .now() + 5)
             logger.error("\(label) timed out after \(Int(waitTimeout))s")
             return DownloadRequestResult(
                 fileURL: existingDownloadFileURL(tempFileURL, fallback: temporaryDownloadURL),

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -171,6 +171,49 @@ import UIKit
         return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorTimedOut
     }
 
+    static func shouldPreserveDownloadTempFile(error: Error?) -> Bool {
+        guard let nsError = error as? NSError else {
+            return false
+        }
+
+        return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
+    }
+
+    private func preserveDownloadedFile(at source: URL, to destination: URL) -> URL? {
+        do {
+            if FileManager.default.fileExists(atPath: destination.path) {
+                try FileManager.default.removeItem(at: destination)
+            }
+            try FileManager.default.moveItem(at: source, to: destination)
+            return destination
+        } catch {
+            try? FileManager.default.removeItem(at: source)
+            return nil
+        }
+    }
+
+    private func partialFileURL(fromResumeData resumeData: Data, destination: URL) -> URL? {
+        let waitTimeout: TimeInterval = 5
+        let semaphore = DispatchSemaphore(value: 0)
+        var preservedURL: URL?
+        let task = self.urlSession.downloadTask(withResumeData: resumeData) { location, _, error in
+            if let location {
+                if error == nil || Self.shouldPreserveDownloadTempFile(error: error) {
+                    preservedURL = self.preserveDownloadedFile(at: location, to: destination)
+                } else {
+                    try? FileManager.default.removeItem(at: location)
+                }
+            }
+            semaphore.signal()
+        }
+        task.resume()
+        DispatchQueue.global().async {
+            task.cancel(byProducingResumeData: { _ in })
+        }
+        _ = semaphore.wait(timeout: .now() + waitTimeout)
+        return preservedURL
+    }
+
     private lazy var urlSession: URLSession = {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.httpAdditionalHeaders = ["User-Agent": self.userAgent]
@@ -268,6 +311,7 @@ import UIKit
         var tempFileURL: URL?
         var httpResponse: HTTPURLResponse?
         var requestError: Error?
+        var resumeDataFromCancel: Data?
         let temporaryDownloadURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let task = self.urlSession.downloadTask(with: request) { location, response, error in
             httpResponse = response as? HTTPURLResponse
@@ -277,16 +321,16 @@ import UIKit
 
             if let location {
                 if requestError == nil && self.isSuccessfulDownloadStatus(httpResponse?.statusCode) {
-                    do {
-                        if FileManager.default.fileExists(atPath: temporaryDownloadURL.path) {
-                            try FileManager.default.removeItem(at: temporaryDownloadURL)
-                        }
-                        try FileManager.default.moveItem(at: location, to: temporaryDownloadURL)
-                        tempFileURL = temporaryDownloadURL
-                    } catch {
-                        requestError = error
-                        try? FileManager.default.removeItem(at: location)
+                    tempFileURL = self.preserveDownloadedFile(at: location, to: temporaryDownloadURL)
+                    if tempFileURL == nil {
+                        requestError = NSError(
+                            domain: "DownloadError",
+                            code: 1,
+                            userInfo: [NSLocalizedDescriptionKey: "Failed to preserve downloaded file"]
+                        )
                     }
+                } else if Self.shouldPreserveDownloadTempFile(error: requestError) {
+                    tempFileURL = self.preserveDownloadedFile(at: location, to: temporaryDownloadURL)
                 } else {
                     try? FileManager.default.removeItem(at: location)
                 }
@@ -296,8 +340,13 @@ import UIKit
         task.resume()
 
         if semaphore.wait(timeout: .now() + waitTimeout) == .timedOut {
-            task.cancel()
+            task.cancel(byProducingResumeData: { resumeData in
+                resumeDataFromCancel = resumeData
+            })
             _ = semaphore.wait(timeout: .now() + 5)
+            if tempFileURL == nil, let resumeData = resumeDataFromCancel {
+                tempFileURL = partialFileURL(fromResumeData: resumeData, destination: temporaryDownloadURL)
+            }
             logger.error("\(label) timed out after \(Int(waitTimeout))s")
             return DownloadRequestResult(
                 fileURL: existingDownloadFileURL(tempFileURL, fallback: temporaryDownloadURL),

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -192,11 +192,21 @@ import UIKit
         }
     }
 
-    private func shouldPreserveDownloadedTempFile(error: Error?, statusCode: Int?) -> Bool {
-        if Self.shouldPreserveDownloadTempFile(error: error) {
+    static func shouldPreserveDownloadedTempFile(error: Error?, statusCode: Int?) -> Bool {
+        if let statusCode, !isSuccessfulDownloadStatus(statusCode) {
+            return false
+        }
+        if shouldPreserveDownloadTempFile(error: error) {
             return true
         }
         return error == nil && isSuccessfulDownloadStatus(statusCode)
+    }
+
+    private static func isSuccessfulDownloadStatus(_ statusCode: Int?) -> Bool {
+        guard let statusCode else {
+            return false
+        }
+        return statusCode >= 200 && statusCode < 300
     }
 
     private func partialFileURL(fromResumeData resumeData: Data, destination: URL) -> URL? {
@@ -206,7 +216,7 @@ import UIKit
         let task = self.urlSession.downloadTask(withResumeData: resumeData) { location, response, error in
             let statusCode = (response as? HTTPURLResponse)?.statusCode
             if let location {
-                if self.shouldPreserveDownloadedTempFile(error: error, statusCode: statusCode) {
+                if Self.shouldPreserveDownloadedTempFile(error: error, statusCode: statusCode) {
                     preservedURL = self.preserveDownloadedFile(at: location, to: destination)
                 } else {
                     try? FileManager.default.removeItem(at: location)
@@ -306,13 +316,6 @@ import UIKit
         return RequestResult(data: responseData, response: httpResponse, error: requestError, timedOut: false)
     }
 
-    private func isSuccessfulDownloadStatus(_ statusCode: Int?) -> Bool {
-        guard let statusCode else {
-            return false
-        }
-        return statusCode >= 200 && statusCode < 300
-    }
-
     private func performDownloadRequest(_ request: URLRequest, label: String) -> DownloadRequestResult {
         let waitTimeout = max(self.timeout + 5, 10)
         let semaphore = DispatchSemaphore(value: 0)
@@ -328,7 +331,7 @@ import UIKit
             }
 
             if let location {
-                if requestError == nil && self.isSuccessfulDownloadStatus(httpResponse?.statusCode) {
+                if requestError == nil && Self.isSuccessfulDownloadStatus(httpResponse?.statusCode) {
                     tempFileURL = self.preserveDownloadedFile(at: location, to: temporaryDownloadURL)
                     if tempFileURL == nil {
                         requestError = NSError(

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -276,7 +276,7 @@ import UIKit
             }
 
             if let location {
-                if requestError == nil && isSuccessfulDownloadStatus(httpResponse?.statusCode) {
+                if requestError == nil && self.isSuccessfulDownloadStatus(httpResponse?.statusCode) {
                     do {
                         if FileManager.default.fileExists(atPath: temporaryDownloadURL.path) {
                             try FileManager.default.removeItem(at: temporaryDownloadURL)

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 import ZIPFoundation
-import Alamofire
 import Compression
 import UIKit
 
@@ -172,7 +171,7 @@ import UIKit
         return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorTimedOut
     }
 
-    private lazy var alamofireSession: Session = {
+    private lazy var urlSession: URLSession = {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.httpAdditionalHeaders = ["User-Agent": self.userAgent]
         configuration.httpCookieStorage = nil
@@ -180,9 +179,8 @@ import UIKit
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
         configuration.urlCache = nil
         configuration.httpMaximumConnectionsPerHost = Self.manifestMaxConcurrentFiles
-        return Session(configuration: configuration)
+        return URLSession(configuration: configuration)
     }()
-    private let networkResponseQueue = DispatchQueue(label: "ee.forgr.capacitor-updater.network-response", qos: .utility)
 
     public var notifyDownloadRaw: (String, Int, Bool, BundleInfo?) -> Void = { _, _, _, _  in }
     public func notifyDownload(id: String, percent: Int, ignoreMultipleOfTen: Bool = false, bundle: BundleInfo? = nil) {
@@ -239,16 +237,16 @@ import UIKit
         var responseData: Data?
         var httpResponse: HTTPURLResponse?
         var requestError: Error?
-        let dataRequest = self.alamofireSession.request(request).responseData(queue: self.networkResponseQueue) { response in
-            responseData = response.data
-            httpResponse = response.response
-            requestError = response.error
+        let task = self.urlSession.dataTask(with: request) { data, response, error in
+            responseData = data
+            httpResponse = response as? HTTPURLResponse
+            requestError = error
             semaphore.signal()
         }
-        dataRequest.resume()
+        task.resume()
 
         if semaphore.wait(timeout: .now() + waitTimeout) == .timedOut {
-            dataRequest.cancel()
+            task.cancel()
             logger.error("\(label) timed out after \(Int(waitTimeout))s")
             return RequestResult(data: responseData, response: httpResponse, error: requestError, timedOut: true)
         }
@@ -263,19 +261,28 @@ import UIKit
         var httpResponse: HTTPURLResponse?
         var requestError: Error?
         let temporaryDownloadURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        let destination: DownloadRequest.Destination = { _, _ in
-            (temporaryDownloadURL, [.removePreviousFile, .createIntermediateDirectories])
-        }
-        let downloadRequest = self.alamofireSession.download(request, to: destination).response(queue: self.networkResponseQueue) { response in
-            tempFileURL = response.fileURL
-            httpResponse = response.response
-            requestError = response.error
+        let task = self.urlSession.downloadTask(with: request) { location, response, error in
+            if let location {
+                do {
+                    if FileManager.default.fileExists(atPath: temporaryDownloadURL.path) {
+                        try FileManager.default.removeItem(at: temporaryDownloadURL)
+                    }
+                    try FileManager.default.moveItem(at: location, to: temporaryDownloadURL)
+                    tempFileURL = temporaryDownloadURL
+                } catch {
+                    requestError = error
+                }
+            }
+            httpResponse = response as? HTTPURLResponse
+            if requestError == nil {
+                requestError = error
+            }
             semaphore.signal()
         }
-        downloadRequest.resume()
+        task.resume()
 
         if semaphore.wait(timeout: .now() + waitTimeout) == .timedOut {
-            downloadRequest.cancel()
+            task.cancel()
             logger.error("\(label) timed out after \(Int(waitTimeout))s")
             return DownloadRequestResult(
                 fileURL: existingDownloadFileURL(tempFileURL, fallback: temporaryDownloadURL),
@@ -666,30 +673,30 @@ import UIKit
         parameters.version_name = current.getVersionName()
         parameters.old_version_name = ""
 
+        guard let url = URL(string: self.statsUrl),
+              let request = createRequest(url: url, method: "POST", parameters: parameters.toParameters()) else {
+            CapgoUpdater.releaseRateLimitStatisticClaim()
+            return
+        }
+
         // Send synchronously using semaphore (safe because we're on a background queue)
         let semaphore = DispatchSemaphore(value: 0)
-        self.alamofireSession.request(
-            self.statsUrl,
-            method: .post,
-            parameters: parameters.toParameters(),
-            encoding: JSONEncoding.default,
-            requestModifier: { $0.timeoutInterval = self.timeout }
-        ).responseData { response in
-            let statusCode = response.response?.statusCode
-            switch response.result {
-            case .success where (200...299).contains(statusCode ?? 0):
+        let task = self.urlSession.dataTask(with: request) { data, response, error in
+            let statusCode = (response as? HTTPURLResponse)?.statusCode
+            if error == nil, let statusCode, (200...299).contains(statusCode) {
                 self.logger.info("Rate limit statistic sent")
-            case .success:
+            } else if error == nil {
                 CapgoUpdater.releaseRateLimitStatisticClaim()
                 self.logger.error("Error sending rate limit statistic")
                 self.logger.debug("Response code: \(statusCode.map(String.init) ?? "nil")")
-            case let .failure(error):
+            } else {
                 CapgoUpdater.releaseRateLimitStatisticClaim()
                 self.logger.error("Error sending rate limit statistic")
-                self.logger.debug("Error: \(error.localizedDescription)")
+                self.logger.debug("Error: \(error!.localizedDescription)")
             }
             semaphore.signal()
         }
+        task.resume()
         semaphore.wait()
     }
 
@@ -3301,24 +3308,49 @@ import UIKit
 
         let operation = BlockOperation {
             let semaphore = DispatchSemaphore(value: 0)
-            self.alamofireSession.request(
-                self.statsUrl,
-                method: .post,
-                parameters: eventsToSend,
-                encoder: JSONParameterEncoder.default,
-                requestModifier: { $0.timeoutInterval = self.timeout }
-            ).responseData { response in
+            guard let url = URL(string: self.statsUrl) else {
+                self.requeueStatsEvents(queuedEvents)
+                semaphore.signal()
+                semaphore.wait()
+                if !self.statsStopped {
+                    self.persistStatsQueue()
+                }
+                return
+            }
+
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.timeoutInterval = self.timeout
+            request.setValue(self.userAgent, forHTTPHeaderField: "User-Agent")
+            request.setValue("application/json", forHTTPHeaderField: "Accept")
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            do {
+                request.httpBody = try JSONEncoder().encode(eventsToSend)
+            } catch {
+                self.requeueStatsEvents(queuedEvents)
+                self.logger.error("Error encoding stats batch")
+                self.logger.debug("Error: \(error.localizedDescription)")
+                semaphore.signal()
+                semaphore.wait()
+                if !self.statsStopped {
+                    self.persistStatsQueue()
+                }
+                return
+            }
+
+            let task = self.urlSession.dataTask(with: request) { data, response, error in
+                let httpResponse = response as? HTTPURLResponse
                 if self.abandonStoppedStatsFlush() {
                     semaphore.signal()
                     return
                 }
-                if self.checkAndHandleRateLimitResponse(statusCode: response.response?.statusCode, data: response.data, response: response.response).blocked {
+                if self.checkAndHandleRateLimitResponse(statusCode: httpResponse?.statusCode, data: data, response: httpResponse).blocked {
                     self.requeueStatsEvents(queuedEvents)
                     semaphore.signal()
                     return
                 }
 
-                if let statusCode = response.response?.statusCode, !(200...299).contains(statusCode) {
+                if let statusCode = httpResponse?.statusCode, !(200...299).contains(statusCode) {
                     if CapgoUpdater.isTransientStatsFailure(statusCode) {
                         self.requeueStatsEvents(queuedEvents)
                         self.logger.error("Error sending stats batch")
@@ -3332,19 +3364,20 @@ import UIKit
                     return
                 }
 
-                switch response.result {
-                case .success:
+                if error == nil {
                     self.clearStatsInFlight()
                     self.logger.info("Stats batch sent successfully")
                     self.logger.debug("Sent \(eventsToSend.count) events")
                     self.runStatsCallbacks(queuedEvents)
-                case let .failure(error):
+                } else {
                     self.requeueStatsEvents(queuedEvents)
                     self.logger.error("Error sending stats batch")
-                    self.logger.debug("Response: \(response.value?.debugDescription ?? "nil"), Error: \(error.localizedDescription)")
+                    let bodyPreview = data.flatMap { String(data: $0, encoding: .utf8) } ?? "nil"
+                    self.logger.debug("Response: \(bodyPreview), Error: \(error!.localizedDescription)")
                 }
                 semaphore.signal()
             }
+            task.resume()
             semaphore.wait()
             if !self.statsStopped {
                 self.persistStatsQueue()

--- a/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
@@ -398,6 +398,16 @@ final class StreamDecodeTests: XCTestCase {
         XCTAssertFalse(CapgoUpdater.shouldAppendHttpBody(statusCode: 206, existingBytes: 0))
     }
 
+    func testShouldPreserveDownloadTempFileOnlyForCancelledDownloads() {
+        let cancelled = NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)
+        let timedOut = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)
+        let badRequest = NSError(domain: NSURLErrorDomain, code: NSURLErrorBadURL)
+        XCTAssertTrue(CapgoUpdater.shouldPreserveDownloadTempFile(error: cancelled))
+        XCTAssertFalse(CapgoUpdater.shouldPreserveDownloadTempFile(error: timedOut))
+        XCTAssertFalse(CapgoUpdater.shouldPreserveDownloadTempFile(error: badRequest))
+        XCTAssertFalse(CapgoUpdater.shouldPreserveDownloadTempFile(error: nil))
+    }
+
     func testManifestPartialURLIsStableForSha256AndPath() {
         let cache = FileManager.default.temporaryDirectory.appendingPathComponent("capgo-partial-\(UUID().uuidString)")
         let hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
@@ -408,6 +408,15 @@ final class StreamDecodeTests: XCTestCase {
         XCTAssertFalse(CapgoUpdater.shouldPreserveDownloadTempFile(error: nil))
     }
 
+    func testShouldPreserveDownloadedTempFileRejectsErrorStatusBeforeCancel() {
+        let cancelled = NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)
+        XCTAssertFalse(CapgoUpdater.shouldPreserveDownloadedTempFile(error: cancelled, statusCode: 404))
+        XCTAssertFalse(CapgoUpdater.shouldPreserveDownloadedTempFile(error: cancelled, statusCode: 500))
+        XCTAssertTrue(CapgoUpdater.shouldPreserveDownloadedTempFile(error: cancelled, statusCode: nil))
+        XCTAssertTrue(CapgoUpdater.shouldPreserveDownloadedTempFile(error: nil, statusCode: 200))
+        XCTAssertFalse(CapgoUpdater.shouldPreserveDownloadedTempFile(error: nil, statusCode: 404))
+    }
+
     func testManifestPartialURLIsStableForSha256AndPath() {
         let cache = FileManager.default.temporaryDirectory.appendingPathComponent("capgo-partial-\(UUID().uuidString)")
         let hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Remove Alamofire from SPM, CocoaPods, and `CapgoUpdater.swift`
- Use `URLSession` for sync data requests, downloads, stats batch POST, and rate-limit stats

## Why
Networking maps cleanly to Foundation `URLSession`. Removing Alamofire cuts a large transitive dependency without changing wire behavior.

## How
Reuse the existing ephemeral `URLSessionConfiguration` settings (User-Agent, no cookies/cache, `httpMaximumConnectionsPerHost` cap). `performRequest` / `performDownloadRequest` keep semaphore-based timeouts and cancellation. Stats batch uses `JSONEncoder` on existing `StatsEvent` Codable models.

## Testing
- No Alamofire imports remain in the iOS target
- CI iOS build + unit tests expected to cover networking paths

## Not Tested
- End-to-end download on physical devices in this environment
- Perf A/B vs Alamofire (expected neutral or slightly better — one less abstraction layer)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-975dd7ca-d4aa-44b7-bc22-c8d08712ecab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-975dd7ca-d4aa-44b7-bc22-c8d08712ecab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-updater/pr/894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791472952&installation_model_id=430928&pr_number=894&repository=Cap-go%2Fcapacitor-updater&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-updater%2Fpull%2F894&signature=d4cadd6b1c40915ffde8edfaec80847794d1c42a1ea00a9c88ca1ca6a2f03c4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-updater/pull/894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - iOS update checks and downloads now use native networking for improved reliability.
  - Downloads retain timeout handling, retry behavior, and partial-download recovery.
  - Update statistics continue to be submitted reliably, including batched submissions.
  - Automated testing and build artifact transfers now retry after temporary failures.

- **Maintenance**
  - Removed the previous third-party networking dependency from the iOS distribution configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->