### PR TITLE
ci: grant actions write and retry Maestro web asset uploads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -620,7 +620,7 @@ jobs:
   maestro_android_scenarios:
     permissions:
       contents: read
-      actions: write
+      actions: read
     needs:
       - maestro_web_assets
       - maestro_android_apps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,6 +136,9 @@ jobs:
             .maestro-artifacts
           include-hidden-files: true
           if-no-files-found: error
+      - name: Wait before retrying Maestro web assets upload
+        if: steps.upload_maestro_web_assets_1.outcome == 'failure'
+        run: sleep 15
       - name: Upload reusable Maestro web assets (attempt 2)
         if: steps.upload_maestro_web_assets_1.outcome == 'failure'
         id: upload_maestro_web_assets_2
@@ -143,16 +146,21 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: maestro-web-assets
+          overwrite: true
           path: |
             dist
             .maestro-artifacts
           include-hidden-files: true
           if-no-files-found: error
+      - name: Wait before final Maestro web assets upload
+        if: steps.upload_maestro_web_assets_1.outcome == 'failure' && steps.upload_maestro_web_assets_2.outcome == 'failure'
+        run: sleep 15
       - name: Upload reusable Maestro web assets (attempt 3)
         if: steps.upload_maestro_web_assets_1.outcome == 'failure' && steps.upload_maestro_web_assets_2.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
           name: maestro-web-assets
+          overwrite: true
           path: |
             dist
             .maestro-artifacts
@@ -200,17 +208,62 @@ jobs:
           distribution: 'zulu'
           java-version: '21'
           cache: gradle
-      - name: Download reusable Maestro web assets
+      - name: Download reusable Maestro web assets (attempt 1)
+        id: download_maestro_web_assets_1
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before retrying Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 2)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        id: download_maestro_web_assets_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 3)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets
           path: .
       - name: Build Android app
         run: bun scripts/maestro/prepare-android-scenario.mjs "${{ matrix.scenario }}"
-      - name: Upload Android app
+      - name: Upload Android app (attempt 1)
+        id: upload_android_app_1
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: maestro-android-app-${{ matrix.scenario }}
+          path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
+      - name: Wait before retrying Android app upload
+        if: steps.upload_android_app_1.outcome == 'failure'
+        run: sleep 15
+      - name: Upload Android app (attempt 2)
+        if: steps.upload_android_app_1.outcome == 'failure'
+        id: upload_android_app_2
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}
+          overwrite: true
+          path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
+      - name: Upload Android app (attempt 3)
+        if: steps.upload_android_app_1.outcome == 'failure' && steps.upload_android_app_2.outcome == 'failure'
+        uses: actions/upload-artifact@v7
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}
+          overwrite: true
           path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
 
@@ -236,7 +289,29 @@ jobs:
             node_modules
             example-app/node_modules
           install-example: 'true'
-      - name: Download reusable Maestro web assets
+      - name: Download reusable Maestro web assets (attempt 1)
+        id: download_maestro_web_assets_1
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before retrying Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 2)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        id: download_maestro_web_assets_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 3)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets
@@ -586,12 +661,56 @@ jobs:
         uses: ./.github/actions/setup-maestro
         with:
           maestro-version: ${{ env.MAESTRO_VERSION }}
-      - name: Download reusable Maestro web assets
+      - name: Download reusable Maestro web assets (attempt 1)
+        id: download_maestro_web_assets_1
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: maestro-web-assets
           path: .
-      - name: Download Android app
+      - name: Wait before retrying Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 2)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure'
+        id: download_maestro_web_assets_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Wait before final Maestro web assets download
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        run: sleep 15
+      - name: Download reusable Maestro web assets (attempt 3)
+        if: steps.download_maestro_web_assets_1.outcome == 'failure' && steps.download_maestro_web_assets_2.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-web-assets
+          path: .
+      - name: Download Android app (attempt 1)
+        id: download_android_app_1
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}
+          path: example-app/android/app/build/outputs/apk/debug
+      - name: Wait before retrying Android app download
+        if: steps.download_android_app_1.outcome == 'failure'
+        run: sleep 15
+      - name: Download Android app (attempt 2)
+        if: steps.download_android_app_1.outcome == 'failure'
+        id: download_android_app_2
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-android-app-${{ matrix.scenario }}
+          path: example-app/android/app/build/outputs/apk/debug
+      - name: Wait before final Android app download
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
+        run: sleep 15
+      - name: Download Android app (attempt 3)
+        if: steps.download_android_app_1.outcome == 'failure' && steps.download_android_app_2.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: maestro-android-app-${{ matrix.scenario }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,6 +258,9 @@ jobs:
           overwrite: true
           path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
+      - name: Wait before final Android app upload
+        if: steps.upload_android_app_1.outcome == 'failure' && steps.upload_android_app_2.outcome == 'failure'
+        run: sleep 15
       - name: Upload Android app (attempt 3)
         if: steps.upload_android_app_1.outcome == 'failure' && steps.upload_android_app_2.outcome == 'failure'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,7 @@ jobs:
   maestro_web_assets:
     permissions:
       contents: read
+      actions: write
     timeout-minutes: 10
     runs-on: ubuntu-latest
     name: Build Maestro web assets
@@ -124,7 +125,31 @@ jobs:
           install-example: 'true'
       - name: Build reusable Maestro web assets
         run: bun scripts/maestro/build-bundles.mjs all
-      - name: Upload reusable Maestro web assets
+      - name: Upload reusable Maestro web assets (attempt 1)
+        id: upload_maestro_web_assets_1
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: maestro-web-assets
+          path: |
+            dist
+            .maestro-artifacts
+          include-hidden-files: true
+          if-no-files-found: error
+      - name: Upload reusable Maestro web assets (attempt 2)
+        if: steps.upload_maestro_web_assets_1.outcome == 'failure'
+        id: upload_maestro_web_assets_2
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: maestro-web-assets
+          path: |
+            dist
+            .maestro-artifacts
+          include-hidden-files: true
+          if-no-files-found: error
+      - name: Upload reusable Maestro web assets (attempt 3)
+        if: steps.upload_maestro_web_assets_1.outcome == 'failure' && steps.upload_maestro_web_assets_2.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
           name: maestro-web-assets
@@ -137,6 +162,7 @@ jobs:
   maestro_android_apps:
     permissions:
       contents: read
+      actions: write
     needs: maestro_web_assets
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -191,6 +217,7 @@ jobs:
   maestro_ios_apps:
     permissions:
       contents: read
+      actions: write
     needs: maestro_web_assets
     timeout-minutes: 10
     runs-on: macOS-latest
@@ -257,6 +284,7 @@ jobs:
   maestro_android_example_app:
     permissions:
       contents: read
+      actions: write
     needs:
       - maestro_web_assets
       - maestro_android_apps
@@ -350,6 +378,7 @@ jobs:
   maestro_ios_example_app:
     permissions:
       contents: read
+      actions: write
     needs:
       - maestro_web_assets
       - maestro_ios_apps
@@ -415,6 +444,7 @@ jobs:
   maestro_ios_live_update:
     permissions:
       contents: read
+      actions: write
     needs:
       - maestro_web_assets
       - maestro_ios_apps
@@ -512,6 +542,7 @@ jobs:
   maestro_android_scenarios:
     permissions:
       contents: read
+      actions: write
     needs:
       - maestro_web_assets
       - maestro_android_apps


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Grant `actions: write` to Maestro jobs that upload or download artifacts.
- Retry the `maestro-web-assets` upload up to three times before failing.

## Why
- Fork PR CI can hit transient GitHub Actions 403 errors while finalizing artifact uploads, which blocks Maestro Android/iOS matrix jobs downstream.

## How
- Add `actions: write` to Maestro workflow jobs.
- Wrap the web-assets upload step with two conditional retry attempts.

## Testing
- Verified on PR #891 mirror run `34249773860`: `Build Maestro web assets` passed and Android Maestro app builds started successfully.

## Not Tested
- Full Maestro matrix on main after merge (will be exercised by open PRs including #888).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-907156eb-f3d9-4a46-83a7-90ff91d6b1b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-907156eb-f3d9-4a46-83a7-90ff91d6b1b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-updater/pr/895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791476488&installation_model_id=430928&pr_number=895&repository=Cap-go%2Fcapacitor-updater&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-updater%2Fpull%2F895&signature=065ea60f2c5f246fb629a57d088c7c9442b37b551628f67129970d8d185e7963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-updater/pull/895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved reliability of automated build and test workflows.
  - Artifact uploads and downloads now retry up to three times after transfer failures.
  - Added a short wait between retry attempts to help recover from temporary interruptions.
  - Retried uploads can replace incomplete artifacts, helping ensure downstream jobs receive complete web and mobile assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->